### PR TITLE
Hide "image" property for new configs

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -36,7 +36,6 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     private String vm;
     private String configName;
     private String baseImage;
-    private String image;
     private int numCPUs;
     private int numExecutors;
     private Mode mode;
@@ -49,14 +48,13 @@ public class AgentTemplate implements Describable<AgentTemplate> {
 
     @DataBoundConstructor
     public AgentTemplate(String vmCredentialsId, String vm, boolean createNewVMConfig, String configName,
-            String baseImage, String image, int numCPUs, int numExecutors, String remoteFS, Mode mode,
+            String baseImage, int numCPUs, int numExecutors, String remoteFS, Mode mode,
             String labelString, int idleTerminationMinutes, List<? extends NodeProperty<?>> nodeProperties) {
         this.vmCredentialsId = vmCredentialsId;
         this.vm = vm;
         this.createNewVMConfig = createNewVMConfig;
         this.configName = configName;
         this.baseImage = baseImage;
-        this.image = image;
         this.numCPUs = numCPUs;
         this.numExecutors = numExecutors;
         this.remoteFS = remoteFS;
@@ -92,10 +90,6 @@ public class AgentTemplate implements Describable<AgentTemplate> {
 
     public String getBaseImage() {
         return this.baseImage;
-    }
-
-    public String getImage() {
-        return this.image;
     }
 
     public int getNumCPUs() {
@@ -149,8 +143,8 @@ public class AgentTemplate implements Describable<AgentTemplate> {
             boolean configExist = parent.getVMs().stream().anyMatch(vm -> vm.getVMName().equalsIgnoreCase(configName));
 
             if (!configExist) {
-                parent.createConfiguration(this.configName, this.image, this.baseImage, Constants.DEFAULT_CONFIG_NAME,
-                        this.numCPUs);
+                parent.createConfiguration(this.configName, this.configName, this.baseImage, 
+                    Constants.DEFAULT_CONFIG_NAME, this.numCPUs);
             }
         }
     }

--- a/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
@@ -36,12 +36,11 @@ public class OrkaAgent extends AbstractCloudSlave {
     private String node;
     private String configName;
     private String baseImage;
-    private String image;
     private int numCPUs;
 
     @DataBoundConstructor
     public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId, String vm,
-            String node, boolean createNewVMConfig, String configName, String baseImage, String image, int numCPUs,
+            String node, boolean createNewVMConfig, String configName, String baseImage, int numCPUs,
             int numExecutors, String host, int port, String remoteFS, Mode mode, String labelString,
             RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties)
             throws Descriptor.FormException, IOException {
@@ -57,7 +56,6 @@ public class OrkaAgent extends AbstractCloudSlave {
         this.createNewVMConfig = createNewVMConfig;
         this.configName = configName;
         this.baseImage = baseImage;
-        this.image = image;
         this.numCPUs = numCPUs;
     }
 
@@ -91,10 +89,6 @@ public class OrkaAgent extends AbstractCloudSlave {
 
     public String getBaseImage() {
         return this.baseImage;
-    }
-
-    public String getImage() {
-        return this.image;
     }
 
     public int getNumCPUs() {

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -112,7 +112,7 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
     private boolean createConfiguration(OrkaAgent agent, OrkaClient client, PrintStream logger) throws IOException {
         if (agent.getCreateNewVMConfig()) {
             String configName = agent.getConfigName();
-            String image = agent.getImage();
+            String image = configName;
             String baseImage = agent.getBaseImage();
             int numCPUs = agent.getNumCPUs();
 

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -14,10 +14,6 @@
         <f:entry title="${%Base Image}" field="baseImage">
           <f:select checkMethod="post"/>
         </f:entry>
-
-        <f:entry title="${%Image}" field="image">
-          <f:textbox />
-        </f:entry>
                 
           <f:entry title="${%# of CPUs}" field="numCPUs">
             <select name="numCPUs">

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -31,10 +31,6 @@
       <f:entry title="${%Base Image}" field="baseImage">
         <f:select checkMethod="post"/>
       </f:entry>
-
-      <f:entry title="${%Image}" field="image">
-        <f:textbox />
-      </f:entry>
       
       <f:entry title="${%# of CPUs}" field="numCPUs">
           <select name="numCPUs">

--- a/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
@@ -47,7 +47,7 @@ public class AgentTemplateTest {
     }
 
     private AgentTemplate getAgentTemplate() {
-        return new AgentTemplate("vmCredentialsId", "my-vm", false, "configName", "baseImage", "image", 12, 1,
+        return new AgentTemplate("vmCredentialsId", "my-vm", false, "configName", "baseImage", 12, 1,
                 "remoteFS", Mode.NORMAL, "label", 5, Collections.emptyList());
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
@@ -62,7 +62,7 @@ public class GetTemplateTest {
     }
 
     private AgentTemplate getAgentTemplate(Mode mode, String label) {
-        return new AgentTemplate("vmCredentialsId", "name", false, "configName", "baseImage", "image", 12, 1,
+        return new AgentTemplate("vmCredentialsId", "name", false, "configName", "baseImage", 12, 1,
                 "remoteFS", this.mode, this.label, 5, Collections.emptyList());
     }
 }


### PR DESCRIPTION
The values doesn't make a difference, so we can reuse the name of the config.
Remove the property as it can only confuse users