### PR TITLE
Allow node host address to be overwritten

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AddressMapper.java
+++ b/src/main/java/io/jenkins/plugins/orka/AddressMapper.java
@@ -1,0 +1,44 @@
+package io.jenkins.plugins.orka;
+
+import hudson.Extension;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class AddressMapper implements Describable<AddressMapper> {
+    private String defaultHost;
+    private String redirectHost;
+
+    @DataBoundConstructor
+    public AddressMapper(String defaultHost, String redirectHost) {
+        this.defaultHost = defaultHost;
+        this.redirectHost = redirectHost;
+    }
+
+    public String getDefaultHost() {
+        return this.defaultHost;
+    }
+
+    public String getRedirectHost() {
+        return this.redirectHost;
+    }
+
+    public void setDefaultHost(String defaultHost) {
+        this.defaultHost = defaultHost;
+    }
+
+    public void setRedirectHost(String redirectHost) {
+        this.redirectHost = redirectHost;
+    }
+
+    @Override
+    public Descriptor<AddressMapper> getDescriptor() {
+        return Jenkins.getInstance().getDescriptor(getClass());
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends Descriptor<AddressMapper> {
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -138,8 +138,9 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         this.ensureConfigurationExist();
         String vmName = this.createNewVMConfig ? this.configName : this.vm;
         DeploymentResponse response = this.parent.deployVM(vmName, node);
+        String host = this.parent.getRealHost(response.getHost());
 
-        return new OrkaProvisionedAgent(this.parent.getDisplayName(), response.getId(), node, response.getHost(),
+        return new OrkaProvisionedAgent(this.parent.getDisplayName(), response.getId(), node, host,
                 response.getSSHPort(), this.vmCredentialsId, this.numExecutors, this.remoteFS, this.mode,
                 this.labelString, this.retentionStrategy, this.nodeProperties);
     }

--- a/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
@@ -40,12 +40,12 @@ public class OrkaAgent extends AbstractCloudSlave {
 
     @DataBoundConstructor
     public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId, String vm,
-            String node, boolean createNewVMConfig, String configName, String baseImage, int numCPUs,
-            int numExecutors, String host, int port, String remoteFS, Mode mode, String labelString,
+            String node, String redirectHost, boolean createNewVMConfig, String configName, String baseImage,
+            int numCPUs, int numExecutors, String host, int port, String remoteFS, Mode mode, String labelString,
             RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties)
             throws Descriptor.FormException, IOException {
 
-        super(name, null, remoteFS, numExecutors, mode, labelString, new OrkaComputerLauncher(host, port),
+        super(name, null, remoteFS, numExecutors, mode, labelString, new OrkaComputerLauncher(host, port, redirectHost),
                 retentionStrategy, nodeProperties);
 
         this.orkaCredentialsId = orkaCredentialsId;
@@ -136,7 +136,7 @@ public class OrkaAgent extends AbstractCloudSlave {
 
             return this.formValidator.doCheckConfigName(configName, orkaEndpoint, orkaCredentialsId, createNewVMConfig);
         }
-        
+
         @POST
         public FormValidation doCheckNode(@QueryParameter String value, @QueryParameter String orkaEndpoint,
                 @QueryParameter String orkaCredentialsId, @QueryParameter String vm,

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -36,12 +36,14 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
     private int retryWaitTime = 30;
 
     private transient SSHLauncher launcher;
+    private transient String redirectHost;
     private String host;
     private int port;
 
-    public OrkaComputerLauncher(String host, int port) {
+    public OrkaComputerLauncher(String host, int port, String redirectHost) {
         this.host = host;
         this.port = port;
+        this.redirectHost = redirectHost;
     }
 
     public String getHost() {
@@ -53,8 +55,7 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
     }
 
     @Override
-    public void launch(SlaveComputer slaveComputer, TaskListener listener)
-            throws IOException, InterruptedException {
+    public void launch(SlaveComputer slaveComputer, TaskListener listener) throws IOException, InterruptedException {
 
         OrkaAgent agent = (OrkaAgent) slaveComputer.getNode();
 
@@ -79,7 +80,7 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
             return;
         }
 
-        this.host = deploymentResponse.getHost();
+        this.host = StringUtils.isNotBlank(this.redirectHost) ? redirectHost : deploymentResponse.getHost();
         this.port = deploymentResponse.getSSHPort();
         this.launcher = this.getLauncher(agent.getVmCredentialsId());
         Jenkins.getInstance().updateNode(slaveComputer.getNode());

--- a/src/main/resources/io/jenkins/plugins/orka/AddressMapper/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AddressMapper/config.jelly
@@ -1,0 +1,17 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/io/jenkins/temp/jelly">
+  <table width="100%">
+    <f:entry title="Private Host" field="defaultHost">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Public Host" field="redirectHost">
+      <f:textbox />
+    </f:entry>
+
+    <f:entry title="">
+      <div align="right">
+        <f:repeatableDeleteButton value="${%Delete Mapping}"/>
+      </div>
+    </f:entry>
+  </table>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/orka/AddressMapper/help-defaultHost.html
+++ b/src/main/resources/io/jenkins/plugins/orka/AddressMapper/help-defaultHost.html
@@ -1,0 +1,4 @@
+<div>
+  Node address within the Orka environment as listed by
+  <b>$ orka node list</b> or <b>GET /resources/node/list</b>
+</div>

--- a/src/main/resources/io/jenkins/plugins/orka/AddressMapper/help-redirectHost.html
+++ b/src/main/resources/io/jenkins/plugins/orka/AddressMapper/help-redirectHost.html
@@ -1,0 +1,1 @@
+<div>Public node address as provided by the MacStadium team</div>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -19,6 +19,12 @@
       <f:select checkMethod="post"/>
     </f:entry>
 
+    <f:advanced>
+      <f:entry title="Public Host" field="redirectHost">
+        <f:textbox />
+      </f:entry>
+    </f:advanced>
+
     <f:entry title="${%VM}" field="vm">
       <f:select checkMethod="post"/>
     </f:entry>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/help-redirectHost.html
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/help-redirectHost.html
@@ -1,0 +1,1 @@
+<div>(Optional) Public node address as provided by the MacStadium team. Leave empty if you want to use the default node address.</div>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/config.jelly
@@ -15,6 +15,14 @@
       <f:textbox />
     </f:entry>
 
+    <f:advanced>
+      <f:entry title="${%Node Mappings}" description="${%List of Orka node mappings}">
+          <f:repeatable field="mappings" header="${%Mapping}" add="${%Add mapping}">
+              <st:include page="config.jelly" class="${descriptor.clazz}"/>
+          </f:repeatable>
+      </f:entry>
+    </f:advanced>
+
   </f:section>
 
     <f:entry title="${%Templates}" description="${%List of VMs to be created as agents}">

--- a/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
@@ -29,6 +29,7 @@ public class AgentTemplateTest {
 
         OrkaCloud cloud = mock(OrkaCloud.class);
         when(cloud.deployVM(anyString(), anyString())).thenReturn(new DeploymentResponse(ip, sshPort, id, null, null));
+        when(cloud.getRealHost(anyString())).thenReturn(ip);
         AgentTemplate.setParent(cloud);
 
         String node = "macpro-1";
@@ -47,7 +48,7 @@ public class AgentTemplateTest {
     }
 
     private AgentTemplate getAgentTemplate() {
-        return new AgentTemplate("vmCredentialsId", "my-vm", false, "configName", "baseImage", 12, 1,
-                "remoteFS", Mode.NORMAL, "label", new IdleTimeCloudRetentionStrategy(5), Collections.emptyList());
+        return new AgentTemplate("vmCredentialsId", "my-vm", false, "configName", "baseImage", 12, 1, "remoteFS",
+                Mode.NORMAL, "label", new IdleTimeCloudRetentionStrategy(5), Collections.emptyList());
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
@@ -49,7 +49,7 @@ public class GetTemplateTest {
     @Test
     public void when_get_template_should_find_template_with_label() throws IOException, ANTLRException {
         AgentTemplate AgentTemplate = this.getAgentTemplate(this.mode, this.label);
-        OrkaCloud cloud = new OrkaCloud("cloud", "credentialsId", "endpoint", Arrays.asList(AgentTemplate));
+        OrkaCloud cloud = new OrkaCloud("cloud", "credentialsId", "endpoint", null, Arrays.asList(AgentTemplate));
 
         Label label = this.labelToLookFor != null ? Label.parseExpression(this.labelToLookFor) : null;
         AgentTemplate resultTemplate = cloud.getTemplate(label);
@@ -62,7 +62,7 @@ public class GetTemplateTest {
     }
 
     private AgentTemplate getAgentTemplate(Mode mode, String label) {
-        return new AgentTemplate("vmCredentialsId", "name", false, "configName", "baseImage", 12, 1,
-                "remoteFS", this.mode, this.label, new IdleTimeCloudRetentionStrategy(5), Collections.emptyList());
+        return new AgentTemplate("vmCredentialsId", "name", false, "configName", "baseImage", 12, 1, "remoteFS",
+                this.mode, this.label, new IdleTimeCloudRetentionStrategy(5), Collections.emptyList());
     }
 }


### PR DESCRIPTION
Node host addresses may be in conflict with local networks.
Allow users to overwrite addresses and use public ones, which will be used to connect to Orka VMs.1