### PR TITLE
Hanlde failed deployments correctly

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -148,6 +148,11 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         logger.fine("Result deploying VM " + vmName + ":");
         logger.fine(response.toString());
 
+        if (response.hasErrors()) {
+            logger.warning("Deploying VM failed with: " + Arrays.toString(response.getErrors()));
+            return null;
+        }
+
         String host = this.parent.getRealHost(response.getHost());
 
         return new OrkaProvisionedAgent(this.parent.getDisplayName(), response.getId(), response.getHost(), host,

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -162,10 +162,12 @@ public class OrkaCloud extends Cloud {
 
                 OrkaProvisionedAgent agent = template.provision();
 
-                logger.fine(provisionIdString + "Adding Node to Jenkins:");
-                logger.fine(agent.toString());
+                if (agent != null) {
+                    logger.fine(provisionIdString + "Adding Node to Jenkins:");
+                    logger.fine(agent.toString());
 
-                Jenkins.getInstance().addNode(agent);
+                    Jenkins.getInstance().addNode(agent);
+                }
 
                 return agent;
             }


### PR DESCRIPTION
When creating ephemeral agents make sure the deployment is succesfull.
If there any errors display them and return an empty result. This will force Jenkins to retry.