### PR TITLE
Increase Orka request timeout to 5 min

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -22,7 +22,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 public class OrkaClient implements AutoCloseable {
-    private static final OkHttpClient client = new OkHttpClient.Builder().readTimeout(60, TimeUnit.SECONDS).build();
+    private static final OkHttpClient client = new OkHttpClient.Builder().readTimeout(300, TimeUnit.SECONDS).build();
     private static final Logger logger = Logger.getLogger(OrkaClient.class.getName());
 
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");


### PR DESCRIPTION
If the API is under heavy load (deployment of 10+ VMs) some requests may fail leaving orpahned VMs.

Increase the timeout to mitigate that.