### PR TITLE
Make sure running instances are always a positive number

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/helpers/CapacityHandler.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/CapacityHandler.java
@@ -90,7 +90,8 @@ public class CapacityHandler {
         try {
             instanceLock.lock();
             this.ensureRunningInstancesInitialized();
-            this.runningInstances--;
+            this.runningInstances = this.runningInstances > 0 ? this.runningInstances - 1 : 0;
+
             logger.fine(String.format("New running instances: %s", this.runningInstances));
         } finally {
             instanceLock.unlock();
@@ -101,7 +102,9 @@ public class CapacityHandler {
         logger.fine("Removing planned instance...");
         try {
             instanceLock.lock();
-            this.plannedInstances--;
+            this.plannedInstances = this.plannedInstances > 0 ? this.plannedInstances - 1 : 0;
+
+
             logger.fine(String.format("New planned instances: %s", this.plannedInstances));
         } finally {
             instanceLock.unlock();

--- a/src/test/java/io/jenkins/plugins/orka/helpers/CapacityHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/helpers/CapacityHandlerTest.java
@@ -160,6 +160,27 @@ public class CapacityHandlerTest {
     }
 
     @Test
+    public void when_reserve_eight_instances_and_no_running_should_return_eight() {
+        int capacity = 8;
+        CapacityHandler handler = new CapacityHandler("cloud", capacity);
+        handler.reserveCapacity(3, "provisionIdString");
+        handler.addRunningInstance();
+        handler.removeRunningInstance();
+        handler.addRunningInstance();
+        handler.removeRunningInstance();
+        handler.addRunningInstance();
+        handler.removeRunningInstance();
+        handler.removeRunningInstance();
+        handler.removeRunningInstance();
+        handler.removeRunningInstance();
+        int capacityToReserve = 8;
+
+        int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
+
+        assertEquals(8, actualReserved);
+    }
+
+    @Test
     public void when_reserve_three_instances_and_four_available_should_return_three() {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);


### PR DESCRIPTION
Pressing the remove instance button more than once leads to negative numbers. Make sure this does not happen