### PR TITLE
Fix node mode selection in the UI

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -30,7 +30,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -56,7 +56,7 @@
         </j:forEach>
       </f:dropdownList>
 
-      <f:slave-mode name="mode" node="${it}"/>
+      <f:slave-mode name="mode" node="${instance}"/>
 
       </f:section>
 

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -63,7 +63,7 @@
         <f:textbox/>
     </f:entry>
 
-    <f:slave-mode name="mode" node="${it}"/>
+    <f:slave-mode name="mode" node="${instance}"/>
 
     <j:if test="${h.getRetentionStrategyDescriptors().size() gt 1}">
         <f:dropdownList name="slave.retentionStrategy" title="${%Availability}"

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaComputer/configure.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaComputer/configure.jelly
@@ -65,7 +65,7 @@
               <f:textbox/>
           </f:entry>
 
-          <f:slave-mode name="mode" node="${it}"/>
+          <f:slave-mode name="mode" node="${instance}"/>
 
           <j:if test="${h.getRetentionStrategyDescriptors().size() gt 1}">
             <f:dropdownList name="slave.retentionStrategy" title="${%Availability}"

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/configure-entries.jelly
@@ -43,7 +43,7 @@
         <f:textbox />
     </f:entry>
 
-    <f:slave-mode name="mode" node="${it}"/>
+    <f:slave-mode name="mode" node="${instance}"/>
 
     <f:dropdownList name="retentionStrategy" title="${%Retention Strategy}" help="${descriptor.getHelpFile('retentionStrategy')}">
       <j:forEach var="d" items="${descriptor.getRetentionStrategyDescriptors()}">


### PR DESCRIPTION
We were not showing the correct selected item for the node mode.
The issue was caused by not using the correct instance object to find out which is the selected item