### PR TITLE
Introduce agent verification strategies

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -33,6 +33,10 @@
     </module>
 
     <module name="TreeWalker">
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="DISABLE CHECKSTYLE"/>
+            <property name="onCommentFormat" value="ENABLE CHECKSTYLE"/>
+        </module>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>

--- a/src/main/java/io/jenkins/plugins/orka/AESVerificationStrategy.java
+++ b/src/main/java/io/jenkins/plugins/orka/AESVerificationStrategy.java
@@ -1,0 +1,109 @@
+package io.jenkins.plugins.orka;
+
+import com.cloudbees.plugins.credentials.common.PasswordCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+import hudson.util.ListBoxModel;
+import hudson.util.Secret;
+import io.jenkins.plugins.orka.helpers.AESDecryptor;
+import io.jenkins.plugins.orka.helpers.CredentialsHelper;
+import io.jenkins.plugins.orka.helpers.SSHUtil;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Base64.Encoder;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class AESVerificationStrategy extends OrkaVerificationStrategy {
+    private static final long serialVersionUID = -5429790217208997430L;
+
+    private static final Logger logger = Logger.getLogger(AESVerificationStrategy.class.getName());
+
+    private static String defaultRemotePath = "/tmp";
+    private String aesKeyId;
+    private String encryptionScript;
+    private String remotePath;
+
+    @DataBoundConstructor
+    public AESVerificationStrategy(String aesKeyId, String encryptionScript, String remotePath) {
+        this.aesKeyId = aesKeyId;
+        this.encryptionScript = encryptionScript;
+        this.remotePath = StringUtils.isNotBlank(remotePath) ? remotePath : defaultRemotePath;
+    }
+
+    public String getAesKeyId() {
+        return this.aesKeyId;
+    }
+
+    public String getEncryptionScript() {
+        return this.encryptionScript;
+    }
+
+    public String getRemotePath() {
+        return this.remotePath;
+    }
+
+    public boolean verify(String host, int sshPort, StandardUsernameCredentials credentials, TaskListener listener) {
+        String hostIdentity = "Host: " + host + ", port: " + sshPort;
+
+        listener.getLogger().println("AES verification for host " + host + " on port " + sshPort);
+        String token = this.generateSafeToken();
+        this.logMessage("Random token: " + token, hostIdentity, listener);
+        String scriptOutput = null;
+        try {
+            scriptOutput = SSHUtil.execute(host, sshPort, credentials, 300, this.encryptionScript, this.remotePath,
+                    token);
+
+            PasswordCredentials aesKey = CredentialsHelper.lookupSystemCredentials(this.aesKeyId,
+                    PasswordCredentials.class);
+            String decryptedToken = AESDecryptor.decrypt(scriptOutput, Secret.toString(aesKey.getPassword())).trim();
+            this.logMessage("Decrypted token: " + decryptedToken, hostIdentity, listener);
+
+            boolean verificationSuccessful = decryptedToken.equals(token);
+            if (!verificationSuccessful) {
+                this.logMessage("AES Verification failed. Script output: " + scriptOutput, hostIdentity, listener);
+            }
+            return verificationSuccessful;
+        } catch (Exception e) {
+            listener.getLogger().println("Exception during AES verification: " + e.toString());
+            logger.log(Level.WARNING, "Exception during AES verification for " + hostIdentity, e);
+            this.logMessage("Script output: " + scriptOutput, hostIdentity, listener);
+        }
+        return false;
+    }
+
+    private String generateSafeToken() {
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[128];
+        random.nextBytes(bytes);
+        Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        return encoder.encodeToString(bytes);
+    }
+
+    private void logMessage(String message, String hostIdentity, TaskListener listener) {
+        listener.getLogger().println(message);
+        logger.fine(hostIdentity + " " + message);
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends OrkaVerificationStrategyDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "AES Verification Strategy";
+        }
+
+        public ListBoxModel doFillAesKeyIdItems() {
+            return CredentialsHelper.getCredentials(PasswordCredentials.class);
+        }
+
+        public String getDefaultRemotePath() {
+            return defaultRemotePath;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/DefaultVerificationStrategy.java
+++ b/src/main/java/io/jenkins/plugins/orka/DefaultVerificationStrategy.java
@@ -1,0 +1,29 @@
+package io.jenkins.plugins.orka;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+
+import hudson.Extension;
+import hudson.model.TaskListener;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class DefaultVerificationStrategy extends OrkaVerificationStrategy {
+    private static final long serialVersionUID = -582491481515659003L;
+
+    @DataBoundConstructor
+    public DefaultVerificationStrategy() {
+    }
+
+    public boolean verify(String host, int sshPort, StandardUsernameCredentials credentials, TaskListener listener) {
+        listener.getLogger().println("Default verification for host " + host + " on port " + sshPort);
+        return true;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends OrkaVerificationStrategyDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Default Verification Strategy";
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/OrkaVerificationStrategy.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaVerificationStrategy.java
@@ -1,0 +1,23 @@
+package io.jenkins.plugins.orka;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.model.TaskListener;
+
+import java.io.Serializable;
+
+public abstract class OrkaVerificationStrategy extends AbstractDescribableImpl<OrkaVerificationStrategy>
+        implements ExtensionPoint, Serializable {
+
+    private static final long serialVersionUID = 8557164621833739416L;
+
+    public boolean verify(String host, int sshPort, StandardUsernameCredentials credentials, TaskListener listener) {
+        return true;
+    }
+
+    public abstract static class OrkaVerificationStrategyDescriptor extends Descriptor<OrkaVerificationStrategy> {
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/WaitSSHLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/WaitSSHLauncher.java
@@ -3,20 +3,22 @@ package io.jenkins.plugins.orka;
 import hudson.model.TaskListener;
 import hudson.plugins.sshslaves.SSHLauncher;
 import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy;
+import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.SlaveComputer;
 import io.jenkins.plugins.orka.helpers.SSHUtil;
 
 import java.io.IOException;
-
 import java.util.logging.Logger;
 
 public final class WaitSSHLauncher extends ComputerLauncher {
     private static final Logger logger = Logger.getLogger(WaitSSHLauncher.class.getName());
 
     private SSHLauncher launcher;
+    private OrkaVerificationStrategy verificationStrategy;
 
-    public WaitSSHLauncher(String host, int sshPort, String vmCredentialsId) {
+    public WaitSSHLauncher(String host, int sshPort, String vmCredentialsId,
+            OrkaVerificationStrategy verificationStrategy) {
         String jvmOptions = null;
         String javaPath = null;
         String prefixStartSlaveCmd = null;
@@ -24,10 +26,20 @@ public final class WaitSSHLauncher extends ComputerLauncher {
         int launchTimeoutSeconds = 300;
         int maxNumRetries = 3;
         int retryWaitTime = 30;
+        this.verificationStrategy = verificationStrategy;
 
         this.launcher = new SSHLauncher(host, sshPort, vmCredentialsId, jvmOptions, javaPath, prefixStartSlaveCmd,
                 suffixStartSlaveCmd, launchTimeoutSeconds, maxNumRetries, retryWaitTime,
                 new NonVerifyingKeyVerificationStrategy());
+
+        readResolve();
+    }
+
+    protected Object readResolve() {
+        if (this.verificationStrategy == null) {
+            this.verificationStrategy = new DefaultVerificationStrategy();
+        }
+        return this;
     }
 
     @Override
@@ -39,14 +51,31 @@ public final class WaitSSHLauncher extends ComputerLauncher {
         int port = launcher.getPort();
 
         listener.getLogger().println("Waiting for SSH to be enabled");
-        logger.fine("Waiting for SSH to be enabled on host  "  + host + " on port " + port);
+        logger.fine("Waiting for SSH to be enabled on host  " + host + " on port " + port);
 
         SSHUtil.waitForSSH(host, port, maxRetries, retryWaitTime);
 
         listener.getLogger().println("SSH enabled");
         logger.fine("SSH enabled on host " + host + " on port " + port);
 
-        this.launcher.launch(slaveComputer, listener);
+        if (this.verificationStrategy.verify(host, port, this.launcher.getCredentials(), listener)) {
+            listener.getLogger().println("Verification successful");
+            logger.fine("Verification successful for host " + host + " on port " + port);
+            this.launcher.launch(slaveComputer, listener);
+        } else {
+            listener.getLogger().println("Verification failed. Deleting node.");
+            logger.fine("Verification failed for host " + host + " on port " + port);
+            this.deleteAgent(slaveComputer);
+        }
+    }
+
+    private void deleteAgent(SlaveComputer slaveComputer) throws InterruptedException, IOException {
+        AbstractCloudSlave node = ((AbstractCloudSlave) slaveComputer.getNode());
+        if (node != null) {
+            node.terminate();
+        } else {
+            slaveComputer.doDoDelete();
+        }
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/orka/helpers/AESDecryptor.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/AESDecryptor.java
@@ -1,0 +1,125 @@
+
+package io.jenkins.plugins.orka.helpers;
+
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.bind.DatatypeConverter;
+
+public class AESDecryptor {
+    private static final Logger logger = Logger.getLogger(AESDecryptor.class.getName());
+
+    private static final int INDEX_KEY = 0;
+    private static final int INDEX_IV = 1;
+    private static final int ITERATIONS = 1;
+
+    private static final int SALT_OFFSET = 8;
+    private static final int SALT_SIZE = 8;
+    private static final int CIPHERTEXT_OFFSET = SALT_OFFSET + SALT_SIZE;
+
+    private static final String CIPHER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
+    private static final String DIGEST = "MD5";
+    private static final String AES = "AES";
+
+    private static final int KEY_SIZE_BITS = 256;
+
+    public static String decrypt(String cypherText, String password) {
+        try {
+            byte[] dataBase64 = DatatypeConverter.parseBase64Binary(cypherText);
+            byte[] salt = Arrays.copyOfRange(dataBase64, SALT_OFFSET, SALT_OFFSET + SALT_SIZE);
+            byte[] encrypted = Arrays.copyOfRange(dataBase64, CIPHERTEXT_OFFSET, dataBase64.length);
+
+            Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+            MessageDigest sha1 = MessageDigest.getInstance(DIGEST);
+
+            final byte[][] keyAndIV = EVP_BytesToKey(KEY_SIZE_BITS / Byte.SIZE, cipher.getBlockSize(), sha1, salt,
+                    password.getBytes("ASCII"), ITERATIONS);
+            SecretKeySpec key = new SecretKeySpec(keyAndIV[INDEX_KEY], AES);
+            IvParameterSpec iv = new IvParameterSpec(keyAndIV[INDEX_IV]);
+
+            cipher.init(Cipher.DECRYPT_MODE, key, iv);
+
+            byte[] decrypted = cipher.doFinal(encrypted);
+            String answer = new String(decrypted, "UTF-8");
+            return answer;
+
+        } catch (Exception ex) {
+            logger.log(Level.WARNING, "Decryption failed", ex);
+        }
+        return null;
+    }
+
+    // DISABLE CHECKSTYLE
+
+    private static byte[][] EVP_BytesToKey(int key_len, int iv_len, MessageDigest md, byte[] salt, byte[] data,
+            int count) {
+        byte[][] both = new byte[2][];
+        byte[] key = new byte[key_len];
+        int key_ix = 0;
+        byte[] iv = new byte[iv_len];
+        int iv_ix = 0;
+        both[0] = key;
+        both[1] = iv;
+        byte[] md_buf = null;
+        int nkey = key_len;
+        int niv = iv_len;
+        int i = 0;
+        if (data == null) {
+            return both;
+        }
+        int addmd = 0;
+        for (;;) {
+            md.reset();
+            if (addmd++ > 0) {
+                md.update(md_buf);
+            }
+            md.update(data);
+            if (null != salt) {
+                md.update(salt, 0, 8);
+            }
+            md_buf = md.digest();
+            for (i = 1; i < count; i++) {
+                md.reset();
+                md.update(md_buf);
+                md_buf = md.digest();
+            }
+            i = 0;
+            if (nkey > 0) {
+                for (;;) {
+                    if (nkey == 0)
+                        break;
+                    if (i == md_buf.length)
+                        break;
+                    key[key_ix++] = md_buf[i];
+                    nkey--;
+                    i++;
+                }
+            }
+            if (niv > 0 && i != md_buf.length) {
+                for (;;) {
+                    if (niv == 0)
+                        break;
+                    if (i == md_buf.length)
+                        break;
+                    iv[iv_ix++] = md_buf[i];
+                    niv--;
+                    i++;
+                }
+            }
+            if (nkey == 0 && niv == 0) {
+                break;
+            }
+        }
+        for (i = 0; i < md_buf.length; i++) {
+            md_buf[i] = 0;
+        }
+        return both;
+    }
+
+    // ENABLE CHECKSTYLE
+}

--- a/src/main/java/io/jenkins/plugins/orka/helpers/CredentialsHelper.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/CredentialsHelper.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.orka.helpers;
 
+import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
@@ -9,9 +10,12 @@ import jenkins.model.Jenkins;
 
 public final class CredentialsHelper {
     public static StandardUsernamePasswordCredentials lookupSystemCredentials(final String credentialsId) {
+        return lookupSystemCredentials(credentialsId, StandardUsernamePasswordCredentials.class);
+    }
+
+    public static <C extends Credentials> C lookupSystemCredentials(final String credentialsId, final Class<C> type) {
         Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
-        return CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class, Jenkins.getInstance()),
+        return CredentialsMatchers.firstOrNull(CredentialsProvider.lookupCredentials(type, Jenkins.getInstance()),
                 CredentialsMatchers.withId(credentialsId));
     }
 

--- a/src/main/java/io/jenkins/plugins/orka/helpers/CryptoUtil.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/CryptoUtil.java
@@ -1,0 +1,65 @@
+package io.jenkins.plugins.orka.helpers;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import javax.crypto.Cipher;
+
+public class CryptoUtil {
+
+    private static final String ALGORITHM = "RSA";
+
+    public static byte[] encrypt(byte[] publicKey, byte[] inputData) throws Exception {
+
+        PublicKey key = KeyFactory.getInstance(ALGORITHM).generatePublic(new X509EncodedKeySpec(publicKey));
+
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+
+        byte[] encryptedBytes = cipher.doFinal(inputData);
+
+        return encryptedBytes;
+    }
+
+    public static byte[] encrypt2(PublicKey publicKey, byte[] inputData) throws Exception {
+
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+
+        byte[] encryptedBytes = cipher.doFinal(inputData);
+
+        return encryptedBytes;
+    }
+
+    public static byte[] decrypt(byte[] privateKey, byte[] inputData) throws Exception {
+
+        PrivateKey key = KeyFactory.getInstance(ALGORITHM).generatePrivate(new PKCS8EncodedKeySpec(privateKey));
+
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, key);
+
+        byte[] decryptedBytes = cipher.doFinal(inputData);
+
+        return decryptedBytes;
+    }
+
+    public static KeyPair generateKeyPair() throws NoSuchAlgorithmException, NoSuchProviderException {
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(ALGORITHM);
+
+        SecureRandom random = SecureRandom.getInstance("SHA1PRNG", "SUN");
+
+        // 512 is keysize
+        keyGen.initialize(512, random);
+
+        KeyPair generateKeyPair = keyGen.generateKeyPair();
+        return generateKeyPair;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaVerificationStrategyProvider.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaVerificationStrategyProvider.java
@@ -1,0 +1,18 @@
+package io.jenkins.plugins.orka.helpers;
+
+import hudson.model.Descriptor;
+import io.jenkins.plugins.orka.DefaultVerificationStrategy;
+import io.jenkins.plugins.orka.OrkaVerificationStrategy;
+import java.util.List;
+import jenkins.model.Jenkins;
+
+public class OrkaVerificationStrategyProvider {
+    public static List<Descriptor<OrkaVerificationStrategy>> getVerificationStrategyDescriptors() {
+        return Jenkins.getInstance().getDescriptorList(OrkaVerificationStrategy.class);
+    }
+
+    public static Descriptor<OrkaVerificationStrategy> getDefaultVerificationDescriptor() {
+        return OrkaVerificationStrategyProvider.getVerificationStrategyDescriptors().stream()
+                .filter(x -> x.getClass().equals(DefaultVerificationStrategy.DescriptorImpl.class)).findFirst().get();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/helpers/SSHUtil.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/SSHUtil.java
@@ -1,8 +1,21 @@
 package io.jenkins.plugins.orka.helpers;
 
+import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.trilead.ssh2.Connection;
+import com.trilead.ssh2.SCPClient;
+import com.trilead.ssh2.ServerHostKeyVerifier;
+import com.trilead.ssh2.Session;
+
+import hudson.model.TaskListener;
+
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class SSHUtil {
     public static boolean waitForSSH(String host, int sshPort, int retries, int secondsBetweenRetries)
@@ -22,5 +35,43 @@ public class SSHUtil {
         }
 
         return false;
+    }
+
+    public static String execute(String host, int sshPort, StandardUsernameCredentials credentials,
+            int launchTimeoutSeconds, String script, String remoteLocation, String args)
+            throws IOException, InterruptedException {
+
+        Connection connection = new Connection(host, sshPort);
+        try {
+            long launchTimeoutMilliseconds = TimeUnit.SECONDS.toMillis(launchTimeoutSeconds);
+            connection.connect(new ServerHostKeyVerifier() {
+                public boolean verifyServerHostKey(String hostname, int port, String serverHostKeyAlgorithm,
+                        byte[] serverHostKey) throws Exception {
+                    return true;
+                }
+            }, (int) launchTimeoutMilliseconds, 0, (int) (launchTimeoutMilliseconds + TimeUnit.SECONDS.toMillis(5)));
+
+            if (SSHAuthenticator.newInstance(connection, credentials).authenticate(TaskListener.NULL)) {
+
+                SCPClient scp = connection.createSCPClient();
+                String scriptName = "orka_handshake.sh";
+                scp.put(script.getBytes("UTF-8"), scriptName, remoteLocation, "0700");
+
+                Session session = connection.openSession();
+                session.requestDumbPTY();
+                session.execCommand(String.format("%s/%s %s", remoteLocation, scriptName, args));
+                session.getStdin().close();
+                session.getStderr().close();
+
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(session.getStdout(), StandardCharsets.UTF_8))) {
+                    return reader.lines().collect(Collectors.joining("\n"));
+                }
+            }
+        } finally {
+            connection.close();
+        }
+
+        return null;
     }
 }

--- a/src/main/resources/io/jenkins/plugins/orka/AESVerificationStrategy/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AESVerificationStrategy/config.jelly
@@ -1,0 +1,14 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:c="/lib/credentials" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="${%Script remote path}" field="remotePath" description="A location on the VM where Jenkins copies and runs the encryption script.">
+      <f:textbox default="${descriptor.getDefaultRemotePath()}"/>
+    </f:entry>
+
+    <f:entry title="${%Encryption script}" field="encryptionScript">
+      <f:textarea />
+    </f:entry>
+
+    <f:entry field="aesKeyId" title="${%AES Key}" description="Symmetric AES key used to decrypt the verification string after it was encrypted on the VM.">
+      <c:select />
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/io/jenkins/plugins/orka/AESVerificationStrategy/help-encryptionScript.html
+++ b/src/main/resources/io/jenkins/plugins/orka/AESVerificationStrategy/help-encryptionScript.html
@@ -1,0 +1,6 @@
+<div>
+  The script that encrypts the randomly-generated verification string with the symmetric AES key available to the VM. 
+  Jenkins automatically creates and passes the randomly-generated verification string as the first argument of this script.
+  This script runs on the VM. Jenkins picks up the script output and decrypts it with its copy of the symmetric AES key. 
+  For more information about how to configure the key and implement the encryption script, contact MacStadium support.
+</div>

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -58,15 +58,19 @@
 
       <f:slave-mode name="mode" node="${instance}"/>
 
-      </f:section>
+      <f:advanced>
+        <f:dropdownDescriptorSelector title="${%Verification Strategy}" field="verificationStrategy" descriptors="${descriptor.getVerificationStrategyDescriptors()}" default="${descriptor.getDefaultVerificationDescriptor()}" />
+      </f:advanced>
 
-      <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}"
-                            field="nodeProperties"/>
+    </f:section>
 
-      <f:entry title="">
-        <div align="right">
-          <f:repeatableDeleteButton value="${%Delete Orka Template}"/>
-        </div>
-      </f:entry>
+    <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}"
+                          field="nodeProperties"/>
+
+    <f:entry title="">
+      <div align="right">
+        <f:repeatableDeleteButton value="${%Delete Orka Template}"/>
+      </div>
+    </f:entry>
   </table>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/help-verificationStrategy.html
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/help-verificationStrategy.html
@@ -1,0 +1,19 @@
+<div>
+  <div>Choose how Jenkins will verify the identity of ephemeral agents before running jobs on them.</div>
+  <ul>
+    <li>
+      <b>Default Verification Strategy</b>: Тhis strategy relies on three verification instruments: VPN, user authentication, and SSH. 
+      All traffic between Jenkins and the Orka environment is secured and encrypted through the dedicated password-protected VPN. 
+      Jenkins authenticates and performs operations against the cluster with a dedicated Orka user. 
+      Jenkins connects to the VM via SSH and authenticates with VM-specific credentials. 
+      The traffic between Jenkins and the VM is further encrypted via SSH.
+      The Default Verification Strategy does not require additional setup.
+    </li>
+    <li>
+      <b>AES Verification Strategy</b>: This strategy adds a fourth verification instrument to the default strategy. 
+      Before running any jobs on a VM, Jenkins further verifies its identity through the exchange and symmetric encryption/decryption of a randomly generated string. 
+      Note: This strategy does not provide additional encryption for the traffic between Jenkins and the VM.
+      To enable AES Verification Strategy and complete its setup, contact MacStadium support.
+    </li>
+  </ul>
+</div>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/configure-entries.jelly
@@ -59,7 +59,9 @@
         </f:dropdownListBlock>
       </j:forEach>
     </f:dropdownList>
-
+    <f:advanced>
+       <f:dropdownDescriptorSelector title="${%Verification Strategy}" field="verificationStrategy" descriptors="${descriptor.getVerificationStrategyDescriptors()}" />
+    </f:advanced>
   </f:section>
 
   <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}"

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/help-verificationStrategy.html
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/help-verificationStrategy.html
@@ -1,0 +1,19 @@
+<div>
+  <div>Choose how Jenkins will verify the identity of ephemeral agents before running jobs on them.</div>
+  <ul>
+    <li>
+      <b>Default Verification Strategy</b>: Тhis strategy relies on three verification instruments: VPN, user authentication, and SSH. 
+      All traffic between Jenkins and the Orka environment is secured and encrypted through the dedicated password-protected VPN. 
+      Jenkins authenticates and performs operations against the cluster with a dedicated Orka user. 
+      Jenkins connects to the VM via SSH and authenticates with VM-specific credentials. 
+      The traffic between Jenkins and the VM is further encrypted via SSH.
+      The Default Verification Strategy does not require additional setup.
+    </li>
+    <li>
+      <b>AES Verification Strategy</b>: This strategy adds a fourth verification instrument to the default strategy. 
+      Before running any jobs on a VM, Jenkins further verifies its identity through the exchange and symmetric encryption/decryption of a randomly generated string. 
+      Note: This strategy does not provide additional encryption for the traffic between Jenkins and the VM.
+      To enable AES Verification Strategy and complete its setup, contact MacStadium support.
+    </li>
+  </ul>
+</div>

--- a/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
@@ -46,6 +46,7 @@ public class AgentTemplateTest {
 
     private AgentTemplate getAgentTemplate() {
         return new AgentTemplate("vmCredentialsId", "my-vm", false, "configName", "baseImage", 12, 1, "remoteFS",
-                Mode.NORMAL, "label", new IdleTimeCloudRetentionStrategy(5), Collections.emptyList());
+                Mode.NORMAL, "label", new IdleTimeCloudRetentionStrategy(5), new DefaultVerificationStrategy(),
+                Collections.emptyList());
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
@@ -49,7 +49,8 @@ public class GetTemplateTest {
     @Test
     public void when_get_template_should_find_template_with_label() throws IOException, ANTLRException {
         AgentTemplate AgentTemplate = this.getAgentTemplate(this.mode, this.label);
-        OrkaCloud cloud = new OrkaCloud("cloud", "credentialsId", "endpoint", null, 0, null, Arrays.asList(AgentTemplate));
+        OrkaCloud cloud = new OrkaCloud("cloud", "credentialsId", "endpoint", null, 0, null,
+                Arrays.asList(AgentTemplate));
 
         Label label = this.labelToLookFor != null ? Label.parseExpression(this.labelToLookFor) : null;
         AgentTemplate resultTemplate = cloud.getTemplate(label);
@@ -63,6 +64,7 @@ public class GetTemplateTest {
 
     private AgentTemplate getAgentTemplate(Mode mode, String label) {
         return new AgentTemplate("vmCredentialsId", "name", false, "configName", "baseImage", 12, 1, "remoteFS",
-                this.mode, this.label, new IdleTimeCloudRetentionStrategy(5), Collections.emptyList());
+                this.mode, this.label, new IdleTimeCloudRetentionStrategy(5), new DefaultVerificationStrategy(),
+                Collections.emptyList());
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/helpers/AESDecryptorTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/helpers/AESDecryptorTest.java
@@ -1,0 +1,44 @@
+package io.jenkins.plugins.orka.helpers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import org.junit.Test;
+
+public class AESDecryptorTest {
+
+    /*
+     * Encrypted values are generated using openssl. Command used: echo value |
+     * openssl enc -a -aes-256-cbc -pass pass:pass This ensures compatibility of the
+     * decryption algorithm with openssl
+     */
+
+    private String long_key = "hvqbqpaqdtmlpoxmcupzneahjwpfyxtf";
+    private String short_key = "key";
+    private String clearText = "extremely_random_text_here";
+
+    @Test
+    public void when_decrypting_with_correct_key_should_decrypt_successfully() {
+        String encryptedText = "U2FsdGVkX18xeT4ilcTy8zG7McxpVqlW5CYpaBPEc0NuIv3cyk/uu13rNJMr9Hq4";
+
+        String decryptedText = AESDecryptor.decrypt(encryptedText, long_key);
+        assertEquals(clearText, decryptedText.trim());
+    }
+
+    @Test
+    public void when_decrypting_with_correct_short_key_should_decrypt_successfully() {
+        String encryptedText = "U2FsdGVkX181Dp2hDTpwuU+aIgdMHVI2T8n+OmZbyPkYsfj3iIl3Qdxtxn55G9P9";
+
+        String decryptedText = AESDecryptor.decrypt(encryptedText, short_key);
+        assertEquals(clearText, decryptedText.trim());
+    }
+
+    @Test
+    public void when_decrypting_with_incorrect_key_should_decrypt_successfully() {
+        String encryptedText = "U2FsdGVkX18+kKML2+05tuu1SW6V242h703lbX0926XWChBAO7/MYy2MOpyGCpsZ";
+
+        String decryptedText = AESDecryptor.decrypt(encryptedText, "short_key");
+        assertEquals(null, decryptedText);
+        assertNotEquals(clearText, decryptedText);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/orka/helpers/CapacityHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/helpers/CapacityHandlerTest.java
@@ -13,7 +13,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Node.Mode;
 import hudson.slaves.RetentionStrategy;
+import io.jenkins.plugins.orka.DefaultVerificationStrategy;
 import io.jenkins.plugins.orka.OrkaProvisionedAgent;
+import io.jenkins.plugins.orka.OrkaVerificationStrategy;
 
 public class CapacityHandlerTest {
     @ClassRule
@@ -242,8 +244,10 @@ public class CapacityHandlerTest {
     public void when_reserve_two_instances_with_one_initial_should_return_two() throws IOException, FormException {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
-        r.getInstance().addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5,
-                "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, Collections.emptyList()));
+        r.getInstance()
+                .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
+                        Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
+                        Collections.emptyList()));
         int capacityToReserve = 2;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -255,8 +259,10 @@ public class CapacityHandlerTest {
     public void when_reserve_five_instances_with_one_initial_should_return_four() throws IOException, FormException {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
-        r.getInstance().addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5,
-                "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, Collections.emptyList()));
+        r.getInstance()
+                .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
+                        Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
+                        Collections.emptyList()));
         int capacityToReserve = 5;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -268,8 +274,10 @@ public class CapacityHandlerTest {
     public void when_reserve_nine_instances_with_one_initial_should_return_four() throws IOException, FormException {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
-        r.getInstance().addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5,
-                "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, Collections.emptyList()));
+        r.getInstance()
+                .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
+                        Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
+                        Collections.emptyList()));
         int capacityToReserve = 9;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -281,8 +289,10 @@ public class CapacityHandlerTest {
             throws IOException, FormException {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
-        r.getInstance().addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
-                "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, Collections.emptyList()));
+        r.getInstance()
+                .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
+                        "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
+                        Collections.emptyList()));
         int capacityToReserve = 2;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -295,8 +305,10 @@ public class CapacityHandlerTest {
             throws IOException, FormException {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
-        r.getInstance().addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
-                "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, Collections.emptyList()));
+        r.getInstance()
+                .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
+                        "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
+                        Collections.emptyList()));
         int capacityToReserve = 5;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -309,8 +321,10 @@ public class CapacityHandlerTest {
             throws IOException, FormException {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
-        r.getInstance().addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
-                "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, Collections.emptyList()));
+        r.getInstance()
+                .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
+                        "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
+                        Collections.emptyList()));
         int capacityToReserve = 9;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");


### PR DESCRIPTION
They allow verifying a VM prior to making it a Jenkins agent.
This way if a VM is not trusted we can delete it and create a new one.

Current strategies:
* Default - rely on VPN and SSH security
* AES - allow users to create a custom AES verification handshake

In addition, allow extensibility of the verification, meaning users can implement their own and plug them into the plugin.