### PR TITLE
Use the HTTP status code to check for errors

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -23,6 +23,7 @@ import io.jenkins.plugins.orka.helpers.OrkaClientProxyFactory;
 import io.jenkins.plugins.orka.helpers.OrkaInfoHelper;
 import io.jenkins.plugins.orka.helpers.OrkaRetentionStrategy;
 import io.jenkins.plugins.orka.helpers.OrkaVerificationStrategyProvider;
+import io.jenkins.plugins.orka.helpers.Utils;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -155,8 +156,8 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         logger.fine("Result deploying VM " + vmName + ":");
         logger.fine(response.toString());
 
-        if (response.hasErrors()) {
-            logger.warning("Deploying VM failed with: " + Arrays.toString(response.getErrors()));
+        if (!response.isSuccessful()) {
+            logger.warning("Deploying VM failed with: " + Utils.getErrorMessage(response));
             return null;
         }
 

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -126,9 +126,9 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
 
             ConfigurationResponse configResponse = clientProxy.createConfiguration(configName, image, baseImage,
                     template, numCPUs);
-            if (configResponse.hasErrors()) {
+            if (!configResponse.isSuccessful()) {
                 logger.println(String.format(configurationErrorFormat, Utils.getTimestamp(), configName, image,
-                        baseImage, template, numCPUs, Arrays.toString(configResponse.getErrors())));
+                        baseImage, template, numCPUs, Utils.getErrorMessage(configResponse)));
                 return false;
             }
             logger.println(
@@ -142,9 +142,9 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
         String vmName = agent.getCreateNewVMConfig() ? agent.getConfigName() : agent.getVm();
 
         DeploymentResponse deploymentResponse = clientProxy.deployVM(vmName, agent.getNode());
-        if (deploymentResponse.hasErrors()) {
+        if (!deploymentResponse.isSuccessful()) {
             logger.println(String.format(deploymentErrorFormat, Utils.getTimestamp(), vmName, agent.getNode(),
-                    Arrays.toString(deploymentResponse.getErrors())));
+                    Utils.getErrorMessage(deploymentResponse)));
             return null;
         }
         logger.println(String.format(deploymentSuccessFormat, Utils.getTimestamp(), deploymentResponse.getMessage()));

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -3,9 +3,10 @@ package io.jenkins.plugins.orka.client;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 
+import io.jenkins.plugins.orka.helpers.Utils;
+
 import java.io.IOException;
 import java.lang.AutoCloseable;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import java.util.logging.Logger;
@@ -182,10 +183,8 @@ public class OrkaClient implements AutoCloseable {
     }
 
     private void verifyToken() throws IOException {
-        HttpResponse response = this.tokenResponse.getHttpResponse();
-        if (!response.getIsSuccessful() || this.tokenResponse.hasErrors()) {
-            String error = String.format("Authentication failed with: Code: %s, Errors: %s ", response.getCode(),
-                    Arrays.toString((this.tokenResponse.getErrors())));
+        if (!this.tokenResponse.isSuccessful()) {
+            String error = String.format("Authentication failed with: %s", Utils.getErrorMessage(tokenResponse));
             throw new IOException(error);
         }
     }

--- a/src/main/java/io/jenkins/plugins/orka/client/ResponseBase.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/ResponseBase.java
@@ -1,5 +1,7 @@
 package io.jenkins.plugins.orka.client;
 
+import java.util.Arrays;
+
 public class ResponseBase {
     private HttpResponse httpResponse;
 
@@ -28,7 +30,18 @@ public class ResponseBase {
         return this.errors.clone();
     }
 
-    public boolean hasErrors() {
+    public boolean isSuccessful() {
+        return this.httpResponse != null ? this.httpResponse.getIsSuccessful() : !this.hasErrors();
+    }
+
+    public String getErrorMessage() {
+        if (!this.isSuccessful()) {
+            return this.hasErrors() ? Arrays.toString(this.getErrors()) : httpResponse.getBody();
+        }
+        return null;
+    }
+
+    private boolean hasErrors() {
         return this.errors != null && this.errors.length > 0;
     }
 }

--- a/src/main/java/io/jenkins/plugins/orka/helpers/Utils.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/Utils.java
@@ -1,9 +1,16 @@
 package io.jenkins.plugins.orka.helpers;
 
+import io.jenkins.plugins.orka.client.ResponseBase;
+
 import java.util.Date;
 
 public class Utils {
     public static String getTimestamp() {
         return String.format("[%1$tD %1$tT]", new Date());
+    }
+
+    public static String getErrorMessage(ResponseBase response) {
+        return String.format("HTTP Code: %s, Error: %s", response.getHttpResponse().getCode(),
+                response.getErrorMessage());
     }
 }


### PR DESCRIPTION
We were using the response body to check if there were any errors.
This could lead to unexpected behavior when the body does not contain an error.
Instead check the status code of the response.