### PR TITLE
Always use HTTP 1.1 for Orka connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -29,9 +30,9 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
-     <dependencies>
+        <tag>HEAD</tag>
+    </scm>
+    <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
@@ -40,17 +41,22 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>3.14.2</version>
-	    </dependency>
+            <version>4.8.0</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
             <version>1.21</version>
-         </dependency>
-         <dependency>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-common</artifactId>
+            <version>1.3.72</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -87,17 +93,17 @@
                 <version>3.1.0</version>
                 <executions>
                     <execution>
-                    <id>checkstyle</id>
-                    <phase>validate</phase>
-                    <goals>
-                        <goal>check</goal>
-                    </goals>
-                    <configuration>
-                        <configLocation>checkstyle.xml</configLocation>
-                        <encoding>UTF-8</encoding>
-                        <consoleOutput>true</consoleOutput>
-                        <failsOnError>true</failsOnError>
-                    </configuration>
+                        <id>checkstyle</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <configLocation>checkstyle.xml</configLocation>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -109,5 +115,5 @@
             <name>Ivan Spasov</name>
             <email>ivan@st6.io</email>
         </developer>
-  </developers>
+    </developers>
 </project>


### PR DESCRIPTION
Okhttp seems to have issues with HTTP 2 and Java 8. Requests fail with various reasons.
Up until OpenJDK 8_242 HTTP 1.1 was used for both http and https requests.
However, OpenJDK 8_252 contains a backport from Java 9, which breaks OkHttp logic.
Two issues appear:
1. The library starts to think we are running under Java 9 instead of Java 8
2. It starts preferring HTTP 2 over HTTP 1

Updating to OkHttp 4.8 fixes the former issue. However, HTTP2 continues to be the preffered protocol.
To fix that issue allow HTTP 1.1 only.