### PR TITLE
Optimize test connection

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -128,6 +128,14 @@ public class OrkaClient implements AutoCloseable {
         return response;
     }
 
+    public TokenStatusResponse getTokenStatus() throws IOException {
+        HttpResponse httpResponse = this.get(this.endpoint + TOKEN_PATH);
+        TokenStatusResponse response = new Gson().fromJson(httpResponse.getBody(), TokenStatusResponse.class);
+        response.setHttpResponse(httpResponse);
+
+        return response;
+    }
+
     public void close() throws IOException {
         this.delete(this.endpoint + TOKEN_PATH, "");
     }

--- a/src/main/java/io/jenkins/plugins/orka/client/TokenStatusResponse.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/TokenStatusResponse.java
@@ -1,0 +1,17 @@
+package io.jenkins.plugins.orka.client;
+
+import com.google.gson.annotations.SerializedName;
+
+public class TokenStatusResponse extends ResponseBase {
+    @SerializedName("authenticated")
+    private boolean isValid;
+
+    public TokenStatusResponse(boolean isValid, String message, OrkaError[] errors) {
+        super(message, errors);
+        this.isValid = isValid;
+    }
+
+    public boolean getIsValid() {
+        return this.isValid;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.orka.helpers;
 
 import hudson.util.FormValidation;
 import io.jenkins.plugins.orka.client.OrkaNode;
+import io.jenkins.plugins.orka.client.TokenStatusResponse;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -31,8 +32,8 @@ public class FormValidator {
 
             try {
                 if (StringUtils.isNotBlank(orkaEndpoint) && orkaCredentialsId != null) {
-                    OrkaClientProxy clientProxy = this.clientProxyFactory.getOrkaClientProxy(orkaEndpoint, 
-                        orkaCredentialsId);
+                    OrkaClientProxy clientProxy = this.clientProxyFactory.getOrkaClientProxy(orkaEndpoint,
+                            orkaCredentialsId);
                     boolean alreadyInUse = clientProxy.getVMs().stream()
                             .anyMatch(vm -> vm.getVMName().equalsIgnoreCase(configName));
                     if (alreadyInUse) {
@@ -94,7 +95,11 @@ public class FormValidator {
         Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
 
         try {
-            new OrkaClientProxyFactory().getOrkaClientProxy(endpoint, credentialsId).getNodes();
+            TokenStatusResponse response = new OrkaClientProxyFactory().getOrkaClientProxy(endpoint, credentialsId)
+                    .getTokenStatus();
+            if (!response.isSuccessful() || !response.getIsValid()) {
+                return failedConnection(Utils.getErrorMessage(response));
+            }
         } catch (IOException e) {
             return failedConnection(e.getMessage());
         }

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
@@ -9,6 +9,7 @@ import io.jenkins.plugins.orka.client.DeploymentResponse;
 import io.jenkins.plugins.orka.client.OrkaClient;
 import io.jenkins.plugins.orka.client.OrkaNode;
 import io.jenkins.plugins.orka.client.OrkaVM;
+import io.jenkins.plugins.orka.client.TokenStatusResponse;
 
 import java.io.IOException;
 import java.util.List;
@@ -83,6 +84,12 @@ public class OrkaClientProxy {
     public DeletionResponse deleteVM(String vmName, String node) throws IOException {
         try (OrkaClient client = getOrkaClient()) {
             return client.deleteVM(vmName, node);
+        }
+    }
+
+    public TokenStatusResponse getTokenStatus() throws IOException {
+        try (OrkaClient client = getOrkaClient()) {
+            return client.getTokenStatus();
         }
     }
 


### PR DESCRIPTION
We were listing all available nodes during test connection
In large clusters this can take some time (10 or more seconds).
Change the check with token status check.