### PR TITLE
Fix the way we handle node properties

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/OrkaProvisionedAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaProvisionedAgent.java
@@ -8,7 +8,9 @@ import hudson.model.TaskListener;
 import hudson.slaves.AbstractCloudComputer;
 import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.NodeProperty;
+import hudson.slaves.NodePropertyDescriptor;
 import hudson.slaves.RetentionStrategy;
+import hudson.util.DescribableList;
 import hudson.util.ListBoxModel;
 import io.jenkins.plugins.orka.helpers.CredentialsHelper;
 import io.jenkins.plugins.orka.helpers.OrkaRetentionStrategy;
@@ -39,7 +41,8 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
     public OrkaProvisionedAgent(String cloudId, String vmId, String node, String host, int sshPort,
             String vmCredentialsId, int numExecutors, String remoteFS, Mode mode, String labelString,
             RetentionStrategy<?> retentionStrategy, OrkaVerificationStrategy verificationStrategy,
-            List<? extends NodeProperty<?>> nodeProperties) throws Descriptor.FormException, IOException {
+            DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties)
+            throws Descriptor.FormException, IOException {
 
         super(vmId, remoteFS, new WaitSSHLauncher(host, sshPort, vmCredentialsId, verificationStrategy));
 
@@ -50,8 +53,9 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
         retentionStrategy = retentionStrategy != null ? retentionStrategy : new IdleTimeCloudRetentionStrategy(30);
         this.setRetentionStrategy(retentionStrategy);
 
-        nodeProperties = nodeProperties != null ? nodeProperties : Collections.<NodeProperty<?>>emptyList();
-        this.setNodeProperties(nodeProperties);
+        List<NodeProperty<?>> nodePropertiesToUse = nodeProperties != null ? nodeProperties.toList()
+                : Collections.<NodeProperty<?>>emptyList();
+        this.setNodeProperties(nodePropertiesToUse);
 
         this.cloudId = cloudId;
         this.vmId = vmId;

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -64,7 +64,7 @@
 
     </f:section>
 
-    <f:descriptorList title="${%Node Properties}" descriptors="${h.getNodePropertyDescriptors(descriptor.clazz)}"
+    <f:descriptorList title="${%Node Properties}" descriptors="${descriptor.getNodePropertyDescriptors()}"
                           field="nodeProperties"/>
 
     <f:entry title="">

--- a/src/test/java/io/jenkins/plugins/orka/helpers/CapacityHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/helpers/CapacityHandlerTest.java
@@ -10,9 +10,11 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import hudson.model.Saveable;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Node.Mode;
 import hudson.slaves.RetentionStrategy;
+import hudson.util.DescribableList;
 import io.jenkins.plugins.orka.DefaultVerificationStrategy;
 import io.jenkins.plugins.orka.OrkaProvisionedAgent;
 
@@ -246,7 +248,7 @@ public class CapacityHandlerTest {
         r.getInstance()
                 .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
                         Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
-                        Collections.emptyList()));
+                        new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 2;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -261,7 +263,7 @@ public class CapacityHandlerTest {
         r.getInstance()
                 .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
                         Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
-                        Collections.emptyList()));
+                        new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 5;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -276,7 +278,7 @@ public class CapacityHandlerTest {
         r.getInstance()
                 .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
                         Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
-                        Collections.emptyList()));
+                        new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 9;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -291,7 +293,7 @@ public class CapacityHandlerTest {
         r.getInstance()
                 .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
                         "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
-                        Collections.emptyList()));
+                        new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 2;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -307,7 +309,7 @@ public class CapacityHandlerTest {
         r.getInstance()
                 .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
                         "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
-                        Collections.emptyList()));
+                        new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 5;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");
@@ -323,7 +325,7 @@ public class CapacityHandlerTest {
         r.getInstance()
                 .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
                         "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
-                        Collections.emptyList()));
+                        new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 9;
 
         int actualReserved = handler.reserveCapacity(capacityToReserve, "provisionIdString");


### PR DESCRIPTION
We had several issues:
1. Node Properties were not persisted in the Cloud configuration
2. Node Properties were limited to "Tools Location" only. Other properties like "Environment Variables" were not available

Causes:
1. We were returning the wrong type
2. We were using the wrong descriptor for node properties. It was AgentTemplate, but it should be OrkaProvisionedAgent as we are assigning the properties to instances of this type