### PR TITLE
Add support for configuration as code

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/IdleTimeCloudRetentionStrategy.java
+++ b/src/main/java/io/jenkins/plugins/orka/IdleTimeCloudRetentionStrategy.java
@@ -1,11 +1,10 @@
 package io.jenkins.plugins.orka;
 
+import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.slaves.CloudRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
 
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class IdleTimeCloudRetentionStrategy extends CloudRetentionStrategy {
@@ -26,7 +25,7 @@ public class IdleTimeCloudRetentionStrategy extends CloudRetentionStrategy {
         return DESCRIPTOR;
     }
 
-    @Restricted(NoExternalUse.class)
+    @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public static final class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {

--- a/src/main/java/io/jenkins/plugins/orka/RunOnceCloudRetentionStrategy.java
+++ b/src/main/java/io/jenkins/plugins/orka/RunOnceCloudRetentionStrategy.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.orka;
 
+import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Executor;
 import hudson.model.ExecutorListener;
@@ -13,8 +14,6 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class RunOnceCloudRetentionStrategy extends CloudRetentionStrategy implements ExecutorListener {
@@ -75,7 +74,7 @@ public class RunOnceCloudRetentionStrategy extends CloudRetentionStrategy implem
         return DESCRIPTOR;
     }
 
-    @Restricted(NoExternalUse.class)
+    @Extension
     public static final DescriptorImpl DESCRIPTOR = new DescriptorImpl();
 
     public static final class DescriptorImpl extends Descriptor<RetentionStrategy<?>> {


### PR DESCRIPTION
The retention strategies could not be set via the Configuration as Code plugin (casc).
The issue is that we do not expose them to Jenkins via an Extension and casc cannot find them.

The fix - expose the retention strategy descriptors