### PR TITLE
Introduce release workflow for the plugin

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,0 +1,24 @@
+name: Release Jenkins Plugin
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release-plugin:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - uses: oleksiyrudenko/gha-git-credentials@v2-latest
+      with:
+        name: github-actions[bot]
+        token: '${{ secrets.GITHUB_TOKEN }}'
+    - uses: s4u/maven-settings-action@v2.2.0
+      with:
+        servers: '[{"id": "maven.jenkins-ci.org", "username": "${{ secrets.MAVEN_SERVER_USER }}", "password": "${{ secrets.MAVEN_SERVER_PASS }}"}]'
+    - name: Prepare and release plugin
+      run: mvn -B release:prepare release:perform

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
     </licenses>
     <url>https://github.com/jenkinsci/macstadium-orka-plugin</url>
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
         <tag>HEAD</tag>
     </scm>


### PR DESCRIPTION
Update the scm connections to use https instead of the git protocol.
This allows us to use the built-in GITHUB_TOKEN in the workflow to update the repo