### PR TITLE
(feat) Allow the user to add a prefix to the cloud agent's name

### DIFF
--- a/integration-tests/jenkins-setup/init-cloud.groovy
+++ b/integration-tests/jenkins-setup/init-cloud.groovy
@@ -29,6 +29,7 @@ String sshPassword =  System.getenv()['SSH_PASSWORD'] ?: "admin";
 
 String vmConfigName = System.getenv()['VM_CONFIG_NAME'] ?: "it-orka-jenkins";
 String agentLabel = System.getenv()['AGENT_LABEL'] ?: "it-orka-agent";
+String agentPrefix = System.getenv()['AGENT_PREFIX'] ?: "it";
 
 String remoteFs = System.getenv()['REMOTE_FS_ROOT'] ?: "/Users/admin";
 
@@ -43,7 +44,7 @@ SystemCredentialsProvider.getInstance().getStore().addCredentials(Domain.global(
 
 AgentTemplate template = new AgentTemplate(sshUserCredentialsId, vmConfigName, false, null, 
     null, 1, 1, remoteFs, 
-    Mode.NORMAL, agentLabel, new IdleTimeCloudRetentionStrategy(30), new DefaultVerificationStrategy(), Collections.emptyList());
+    Mode.NORMAL, agentLabel, agentPrefix, new IdleTimeCloudRetentionStrategy(30), new DefaultVerificationStrategy(), Collections.emptyList());
 
 ArrayList<AgentTemplate> templates = new ArrayList<AgentTemplate>()
 templates.add(template)

--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -54,6 +54,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     private Mode mode;
     private String remoteFS;
     private String labelString;
+    private String namePrefix;
     private RetentionStrategy<?> retentionStrategy;
     private OrkaVerificationStrategy verificationStrategy;
     private DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties;
@@ -66,7 +67,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     @DataBoundConstructor
     public AgentTemplate(String vmCredentialsId, String vm, boolean createNewVMConfig, String configName,
             String baseImage, int numCPUs, int numExecutors, String remoteFS, Mode mode, String labelString,
-            RetentionStrategy<?> retentionStrategy, OrkaVerificationStrategy verificationStrategy,
+            String namePrefix, RetentionStrategy<?> retentionStrategy, OrkaVerificationStrategy verificationStrategy,
             List<? extends NodeProperty<?>> nodeProperties) {
         this.vmCredentialsId = vmCredentialsId;
         this.vm = vm;
@@ -78,6 +79,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         this.remoteFS = remoteFS;
         this.mode = mode;
         this.labelString = labelString;
+        this.namePrefix = namePrefix;
         this.retentionStrategy = retentionStrategy;
         this.verificationStrategy = verificationStrategy;
         this.nodeProperties = new DescribableList<>(Saveable.NOOP, Util.fixNull(nodeProperties));
@@ -121,6 +123,10 @@ public class AgentTemplate implements Describable<AgentTemplate> {
 
     public Set<LabelAtom> getLabelSet() {
         return Label.parse(this.getLabelString());
+    }
+
+    public String getNamePrefix() {
+        return this.namePrefix;
     }
 
     public int getNumExecutors() {
@@ -172,10 +178,12 @@ public class AgentTemplate implements Describable<AgentTemplate> {
             }
 
             String host = this.parent.getRealHost(response.getHost());
+            String vmId = response.getId();
 
-            return new OrkaProvisionedAgent(this.parent.getDisplayName(), response.getId(), response.getHost(), host,
-                    response.getSSHPort(), this.vmCredentialsId, this.numExecutors, this.remoteFS, this.mode,
-                    this.labelString, this.retentionStrategy, this.verificationStrategy, this.nodeProperties);
+            return new OrkaProvisionedAgent(this.parent.getDisplayName(), this.namePrefix, vmId, response.getHost(), 
+                    host, response.getSSHPort(), this.vmCredentialsId, this.numExecutors, this.remoteFS, this.mode,
+                    this.labelString, this.retentionStrategy, this.verificationStrategy, 
+                    this.nodeProperties);
         } catch (Exception e) {
             logger.warning("Exception while creating provisioned agent. Deleting VM.");
             this.parent.deleteVM(response.getId());
@@ -291,9 +299,9 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     public String toString() {
         return "AgentTemplate [baseImage=" + baseImage + ", configName=" + configName + ", createNewVMConfig="
                 + createNewVMConfig + ", idleTerminationMinutes=" + idleTerminationMinutes + ", labelString="
-                + labelString + ", mode=" + mode + ", nodeProperties=" + nodeProperties + ", numCPUs=" + numCPUs
-                + ", numExecutors=" + numExecutors + ", parent=" + parent + ", remoteFS=" + remoteFS
-                + ", retentionStrategy=" + retentionStrategy + ", verificationStrategy=" + verificationStrategy
-                + ", vm=" + vm + ", vmCredentialsId=" + vmCredentialsId + "]";
+                + labelString + ", namePrefix=" + namePrefix + ", mode=" + mode + ", nodeProperties=" 
+                + nodeProperties + ", numCPUs=" + numCPUs + ", numExecutors=" + numExecutors + ", parent=" + parent 
+                + ", remoteFS=" + remoteFS + ", retentionStrategy=" + retentionStrategy + ", verificationStrategy=" 
+                + verificationStrategy + ", vm=" + vm + ", vmCredentialsId=" + vmCredentialsId + "]";
     }
 }

--- a/src/main/java/io/jenkins/plugins/orka/OrkaProvisionedAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaProvisionedAgent.java
@@ -23,6 +23,8 @@ import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 public class OrkaProvisionedAgent extends AbstractCloudSlave {
@@ -35,16 +37,18 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
     private String host;
     private int sshPort;
     private String vmCredentialsId;
+    private String namePrefix;
     private OrkaVerificationStrategy verificationStrategy;
 
     @DataBoundConstructor
-    public OrkaProvisionedAgent(String cloudId, String vmId, String node, String host, int sshPort,
-            String vmCredentialsId, int numExecutors, String remoteFS, Mode mode, String labelString,
-            RetentionStrategy<?> retentionStrategy, OrkaVerificationStrategy verificationStrategy,
-            List<? extends NodeProperty<?>> nodeProperties)
+    public OrkaProvisionedAgent(String cloudId, String namePrefix, String vmId, String node, String host, int sshPort,
+            String vmCredentialsId, int numExecutors, String remoteFS, Mode mode, String labelString, 
+            RetentionStrategy<?> retentionStrategy, 
+            OrkaVerificationStrategy verificationStrategy, List<? extends NodeProperty<?>> nodeProperties)
             throws Descriptor.FormException, IOException {
 
-        super(vmId, remoteFS, new WaitSSHLauncher(host, sshPort, vmCredentialsId, verificationStrategy));
+        super(StringUtils.isNotBlank(namePrefix) ? namePrefix + '_' + vmId : vmId, remoteFS, 
+                new WaitSSHLauncher(host, sshPort, vmCredentialsId, verificationStrategy));
 
         this.setNumExecutors(numExecutors);
         this.setMode(mode);
@@ -63,6 +67,7 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
         this.host = host;
         this.sshPort = sshPort;
         this.vmCredentialsId = vmCredentialsId;
+        this.namePrefix = namePrefix;
         this.verificationStrategy = verificationStrategy;
     }
 
@@ -95,6 +100,10 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
 
     public String getVmCredentialsId() {
         return this.vmCredentialsId;
+    }
+
+    public String getNamePrefix() {
+        return this.namePrefix;
     }
 
     public OrkaVerificationStrategy getVerificationStrategy() {
@@ -149,7 +158,7 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
     @Override
     public String toString() {
         return "OrkaProvisionedAgent [cloudId=" + cloudId + ", host=" + host + ", node=" + node + ", sshPort=" + sshPort
-                + ", vmCredentialsId=" + vmCredentialsId + ", verificationStrategy=" + verificationStrategy + ", vmId="
-                + vmId + "]";
+                + ", vmCredentialsId=" + vmCredentialsId + ", verificationStrategy=" + verificationStrategy 
+                + ", namePrefix=" + namePrefix + "]" + ", vmId=" + vmId + "]";
     }
 }

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -40,6 +40,10 @@
       <f:entry title="${%Labels}" field="labelString">
         <f:textbox/>
       </f:entry>
+      
+      <f:entry title="${%Name Prefix}" field="namePrefix" help="${descriptor.getHelpFile('namePrefix')}">
+        <f:textbox/>
+      </f:entry>
 
       <f:dropdownList name="retentionStrategy" title="${%Retention Strategy}" help="${descriptor.getHelpFile('retentionStrategy')}">
         <j:forEach var="d" items="${descriptor.getRetentionStrategyDescriptors()}">

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/help-namePrefix.html
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/help-namePrefix.html
@@ -1,0 +1,2 @@
+<div>The name prefix is used when naming Jenkins Agents. For example entering name prefix `c6` will name the corresponding agent `c6_5e34ab2c160d0` where `5e34ab2c160d0` is the ID of the underlying VM.
+</div>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/configure-entries.jelly
@@ -1,6 +1,10 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/io/jenkins/temp/jelly">
 
+  <f:invisibleEntry>
+    <f:readOnlyTextbox name="namePrefix" value="${instance.namePrefix}" />
+  </f:invisibleEntry>
+      
   <f:entry title="${%Cloud}" field="cloudId">
     <f:readOnlyTextbox />
   </f:entry>

--- a/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
@@ -46,7 +46,7 @@ public class AgentTemplateTest {
 
     private AgentTemplate getAgentTemplate() {
         return new AgentTemplate("vmCredentialsId", "my-vm", false, "configName", "baseImage", 12, 1, "remoteFS",
-                Mode.NORMAL, "label", new IdleTimeCloudRetentionStrategy(5), new DefaultVerificationStrategy(),
+                Mode.NORMAL, "label", "prefix", new IdleTimeCloudRetentionStrategy(5), new DefaultVerificationStrategy(),
                 Collections.emptyList());
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
@@ -64,7 +64,7 @@ public class GetTemplateTest {
 
     private AgentTemplate getAgentTemplate(Mode mode, String label) {
         return new AgentTemplate("vmCredentialsId", "name", false, "configName", "baseImage", 12, 1, "remoteFS",
-                this.mode, this.label, new IdleTimeCloudRetentionStrategy(5), new DefaultVerificationStrategy(),
+                this.mode, this.label, "prefix", new IdleTimeCloudRetentionStrategy(5), new DefaultVerificationStrategy(),
                 Collections.emptyList());
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/helpers/CapacityHandlerTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/helpers/CapacityHandlerTest.java
@@ -246,7 +246,7 @@ public class CapacityHandlerTest {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
         r.getInstance()
-                .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
+                .addNode(new OrkaProvisionedAgent("cloud", "pre", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
                         Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
                         new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 2;
@@ -261,7 +261,7 @@ public class CapacityHandlerTest {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
         r.getInstance()
-                .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
+                .addNode(new OrkaProvisionedAgent("cloud", "pre", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
                         Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
                         new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 5;
@@ -276,7 +276,7 @@ public class CapacityHandlerTest {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
         r.getInstance()
-                .addNode(new OrkaProvisionedAgent("cloud", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
+                .addNode(new OrkaProvisionedAgent("cloud", "pre", "vmId", "node", "host", 2, "vmCredentialsId", 5, "remoteFS",
                         Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
                         new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 9;
@@ -291,7 +291,7 @@ public class CapacityHandlerTest {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
         r.getInstance()
-                .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
+                .addNode(new OrkaProvisionedAgent("another", "pre", "vmId", "node", "host", 2, "vmCredentialsId", 5,
                         "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
                         new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 2;
@@ -307,7 +307,7 @@ public class CapacityHandlerTest {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
         r.getInstance()
-                .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
+                .addNode(new OrkaProvisionedAgent("another", "pre", "vmId", "node", "host", 2, "vmCredentialsId", 5,
                         "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
                         new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 5;
@@ -323,7 +323,7 @@ public class CapacityHandlerTest {
         int capacity = 5;
         CapacityHandler handler = new CapacityHandler("cloud", capacity);
         r.getInstance()
-                .addNode(new OrkaProvisionedAgent("another", "vmId", "node", "host", 2, "vmCredentialsId", 5,
+                .addNode(new OrkaProvisionedAgent("another", "pre", "vmId", "node", "host", 2, "vmCredentialsId", 5,
                         "remoteFS", Mode.NORMAL, "labelString", RetentionStrategy.NOOP, new DefaultVerificationStrategy(),
                         new DescribableList<>(Saveable.NOOP, Collections.emptyList())));
         int capacityToReserve = 9;


### PR DESCRIPTION
Currently the agents are named on the ID of the VM that stays behind them. With this feature, the user is allowed to specify a prefix in the agents config. The prefix then is added in front of the VM ID and the agent name looks like `prefix_vmid`. This gives the user a better way to distinguish between agents.