### PR TITLE
Use the config endpoint to check for existing configs

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -194,7 +194,8 @@ public class AgentTemplate implements Describable<AgentTemplate> {
 
     private ConfigurationResponse ensureConfigurationExist() throws IOException {
         if (this.createNewVMConfig) {
-            boolean configExist = parent.getVMs().stream().anyMatch(vm -> vm.getVMName().equalsIgnoreCase(configName));
+            boolean configExist = parent.getVMConfigs().stream()
+                    .anyMatch(vm -> vm.getName().equalsIgnoreCase(configName));
 
             if (!configExist) {
                 logger.fine("Creating config with name " + this.configName);

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -15,6 +15,7 @@ import hudson.util.ListBoxModel;
 import io.jenkins.plugins.orka.client.ConfigurationResponse;
 import io.jenkins.plugins.orka.client.DeploymentResponse;
 import io.jenkins.plugins.orka.client.OrkaVM;
+import io.jenkins.plugins.orka.client.OrkaVMConfig;
 import io.jenkins.plugins.orka.helpers.CapacityHandler;
 import io.jenkins.plugins.orka.helpers.CredentialsHelper;
 import io.jenkins.plugins.orka.helpers.FormValidator;
@@ -129,6 +130,11 @@ public class OrkaCloud extends Cloud {
     public List<OrkaVM> getVMs() throws IOException {
         return new OrkaClientProxyFactory()
                 .getOrkaClientProxy(this.endpoint, this.credentialsId, this.useJenkinsProxySettings).getVMs();
+    }
+    
+    public List<OrkaVMConfig> getVMConfigs() throws IOException {
+        return new OrkaClientProxyFactory()
+                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.useJenkinsProxySettings).getVMConfigs();
     }
 
     public ConfigurationResponse createConfiguration(String name, String image, String baseImage, String configTemplate,

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -38,6 +38,7 @@ public class OrkaClient implements AutoCloseable {
     private static final String CREATE_PATH = "/create";
     private static final String DEPLOY_PATH = "/deploy";
     private static final String DELETE_PATH = "/delete";
+    private static final String CONFIG_PATH = "/configs";
 
     private String endpoint;
     private TokenResponse tokenResponse;
@@ -62,6 +63,15 @@ public class OrkaClient implements AutoCloseable {
 
         Gson gson = new Gson();
         VMResponse response = gson.fromJson(httpResponse.getBody(), VMResponse.class);
+        response.setHttpResponse(httpResponse);
+        return response;
+    }
+    
+    public VMConfigResponse getVMConfigs() throws IOException {
+        HttpResponse httpResponse = this.get(this.endpoint + VM_PATH + CONFIG_PATH);
+
+        Gson gson = new Gson();
+        VMConfigResponse response = gson.fromJson(httpResponse.getBody(), VMConfigResponse.class);
         response.setHttpResponse(httpResponse);
         return response;
     }

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaVMConfig.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaVMConfig.java
@@ -1,0 +1,72 @@
+package io.jenkins.plugins.orka.client;
+
+import com.google.gson.annotations.SerializedName;
+
+public class OrkaVMConfig {
+
+    @SerializedName("orka_vm_name")
+    private String name;
+
+    @SerializedName("orka_cpu_core")
+    private int cpuCount;
+
+    @SerializedName("orka_base_image")
+    private String baseImage;
+
+    public OrkaVMConfig(String name, int cpuCount, String baseImage) {
+        this.name = name;
+        this.cpuCount = cpuCount;
+        this.baseImage = baseImage;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getCPUCount() {
+        return this.cpuCount;
+    }
+
+    public String getBaseImage() {
+        return this.baseImage;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((baseImage == null) ? 0 : baseImage.hashCode());
+        result = prime * result + cpuCount;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        OrkaVMConfig other = (OrkaVMConfig) obj;
+        if (baseImage == null) {
+            if (other.baseImage != null) {
+                return false;
+            }
+        } else if (!baseImage.equals(other.baseImage)) {
+            return false;
+        }
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/client/VMConfigResponse.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/VMConfigResponse.java
@@ -1,0 +1,17 @@
+package io.jenkins.plugins.orka.client;
+
+import java.util.Collections;
+import java.util.List;
+
+public class VMConfigResponse extends ResponseBase {
+    private List<OrkaVMConfig> configs;
+
+    public VMConfigResponse(List<OrkaVMConfig> configs, String message, OrkaError[] errors) {
+        super(message, errors);
+        this.configs = configs;
+    }
+
+    public List<OrkaVMConfig> getConfigs() {
+        return this.configs != null ? Collections.unmodifiableList(this.configs) : Collections.emptyList();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
@@ -11,6 +11,7 @@ import io.jenkins.plugins.orka.client.DeploymentResponse;
 import io.jenkins.plugins.orka.client.OrkaClient;
 import io.jenkins.plugins.orka.client.OrkaNode;
 import io.jenkins.plugins.orka.client.OrkaVM;
+import io.jenkins.plugins.orka.client.OrkaVMConfig;
 import io.jenkins.plugins.orka.client.TokenStatusResponse;
 
 import java.io.IOException;
@@ -36,6 +37,12 @@ public class OrkaClientProxy {
     public List<OrkaVM> getVMs() throws IOException {
         try (OrkaClient client = getOrkaClient()) {
             return client.getVMs().getVMs();
+        }
+    }
+    
+    public List<OrkaVMConfig> getVMConfigs() throws IOException {
+        try (OrkaClient client = getOrkaClient()) {
+            return client.getVMConfigs().getConfigs();
         }
     }
 


### PR DESCRIPTION
It is cleaner to use the config endpoint to check for existing configs.
In addition, the vms endpoint may not return a config if it has failed
to deploy, resulting in errors.