### PR TITLE
Make sure we follow Jenkins new layout

### DIFF
--- a/src/main/resources/io/jenkins/plugins/orka/AddressMapper/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AddressMapper/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/io/jenkins/temp/jelly">
-  <table width="100%">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/io/jenkins/temp/jelly" xmlns:orka="/lib/orka">
+  <orka:blockWrapper>
     <f:entry title="Private Host" field="defaultHost">
       <f:textbox />
     </f:entry>
@@ -13,5 +13,5 @@
         <f:repeatableDeleteButton value="${%Delete Mapping}"/>
       </div>
     </f:entry>
-  </table>
+  </orka:blockWrapper>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/io/jenkins/temp/jelly">
-  <table width="100%">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/io/jenkins/temp/jelly" xmlns:orka="/lib/orka">
+  <orka:blockWrapper>
     <f:section title="${%ORKA VM Details}">
       <f:entry title="${%VM}" field="vm">
         <f:select checkMethod="post"/>
@@ -76,5 +76,5 @@
         <f:repeatableDeleteButton value="${%Delete Orka Template}"/>
       </div>
     </f:entry>
-  </table>
+  </orka:blockWrapper>
 </j:jelly>

--- a/src/main/resources/lib/orka/blockWrapper.jelly
+++ b/src/main/resources/lib/orka/blockWrapper.jelly
@@ -1,0 +1,15 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define">
+  <j:choose>
+    <j:when test="${divBasedFormLayout}">
+      <div>
+        <d:invokeBody/>
+      </div>
+    </j:when>
+    <j:otherwise>
+      <table style="width:100%">
+        <d:invokeBody/>
+      </table>
+    </j:otherwise>
+  </j:choose>
+</j:jelly>


### PR DESCRIPTION
Jenkins are moving away from table elements in favor to div.
This is breaking the current layout in the plugin cloud configuration.
Introduce a blockWrapper that is also backwards compatible and changes between table and div depending on the version.
