### PR TITLE
ORKA-857 Allow users to provide JVM options to the Orka agents

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -65,6 +65,14 @@ public class AgentTemplate implements Describable<AgentTemplate> {
 
     private transient OrkaCloud parent;
 
+    public AgentTemplate(String vmCredentialsId, String vm, boolean createNewVMConfig, String configName,
+            String baseImage, int numCPUs, int numExecutors, String remoteFS, Mode mode, String labelString,
+            String namePrefix, RetentionStrategy<?> retentionStrategy, OrkaVerificationStrategy verificationStrategy,
+            List<? extends NodeProperty<?>> nodeProperties) {
+        this(vmCredentialsId, vm, createNewVMConfig, configName, baseImage, numCPUs, numExecutors, remoteFS,
+            mode, labelString, namePrefix, retentionStrategy, verificationStrategy, nodeProperties, null);
+    }
+
     @DataBoundConstructor
     public AgentTemplate(String vmCredentialsId, String vm, boolean createNewVMConfig, String configName,
             String baseImage, int numCPUs, int numExecutors, String remoteFS, Mode mode, String labelString,

--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -58,6 +58,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     private RetentionStrategy<?> retentionStrategy;
     private OrkaVerificationStrategy verificationStrategy;
     private DescribableList<NodeProperty<?>, NodePropertyDescriptor> nodeProperties;
+    private String jvmOptions;
 
     @Deprecated
     private transient int idleTerminationMinutes;
@@ -68,7 +69,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     public AgentTemplate(String vmCredentialsId, String vm, boolean createNewVMConfig, String configName,
             String baseImage, int numCPUs, int numExecutors, String remoteFS, Mode mode, String labelString,
             String namePrefix, RetentionStrategy<?> retentionStrategy, OrkaVerificationStrategy verificationStrategy,
-            List<? extends NodeProperty<?>> nodeProperties) {
+            List<? extends NodeProperty<?>> nodeProperties, String jvmOptions) {
         this.vmCredentialsId = vmCredentialsId;
         this.vm = vm;
         this.createNewVMConfig = createNewVMConfig;
@@ -83,6 +84,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         this.retentionStrategy = retentionStrategy;
         this.verificationStrategy = verificationStrategy;
         this.nodeProperties = new DescribableList<>(Saveable.NOOP, Util.fixNull(nodeProperties));
+        this.jvmOptions = jvmOptions;
     }
 
     public String getOrkaCredentialsId() {
@@ -141,6 +143,10 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         return this.remoteFS;
     }
 
+    public String getJvmOptions() {
+        return this.jvmOptions;
+    }
+
     public RetentionStrategy<?> getRetentionStrategy() {
         return this.retentionStrategy;
     }
@@ -183,7 +189,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
             return new OrkaProvisionedAgent(this.parent.getDisplayName(), this.namePrefix, vmId, response.getHost(), 
                     host, response.getSSHPort(), this.vmCredentialsId, this.numExecutors, this.remoteFS, this.mode,
                     this.labelString, this.retentionStrategy, this.verificationStrategy, 
-                    this.nodeProperties);
+                    this.nodeProperties, this.jvmOptions);
         } catch (Exception e) {
             logger.warning("Exception while creating provisioned agent. Deleting VM.");
             this.parent.deleteVM(response.getId());

--- a/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
@@ -36,6 +36,7 @@ public class OrkaAgent extends AbstractCloudSlave {
     private String configName;
     private String baseImage;
     private int numCPUs;
+    private String jvmOptions;
 
     public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId, String vm,
             String node, String redirectHost, boolean createNewVMConfig, String configName, String baseImage,
@@ -43,17 +44,17 @@ public class OrkaAgent extends AbstractCloudSlave {
             throws Descriptor.FormException, IOException {
 
         this(name, orkaCredentialsId, orkaEndpoint, vmCredentialsId, vm, node, redirectHost, createNewVMConfig,
-                configName, baseImage, numCPUs, numExecutors, host, port, remoteFS, false, false);
+                configName, baseImage, numCPUs, numExecutors, host, port, remoteFS, false, false, null);
     }
     
     @DataBoundConstructor
     public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId, String vm,
             String node, String redirectHost, boolean createNewVMConfig, String configName, String baseImage,
             int numCPUs, int numExecutors, String host, int port, String remoteFS, 
-            boolean useJenkinsProxySettings, boolean ignoreSSLErrors)
+            boolean useJenkinsProxySettings, boolean ignoreSSLErrors, String jvmOptions)
             throws Descriptor.FormException, IOException {
 
-        super(name, remoteFS, new OrkaComputerLauncher(host, port, redirectHost));
+        super(name, remoteFS, new OrkaComputerLauncher(host, port, redirectHost, jvmOptions));
 
         this.orkaCredentialsId = orkaCredentialsId;
         this.orkaEndpoint = orkaEndpoint;
@@ -66,6 +67,7 @@ public class OrkaAgent extends AbstractCloudSlave {
         this.numCPUs = numCPUs;
         this.useJenkinsProxySettings = useJenkinsProxySettings;
         this.ignoreSSLErrors = ignoreSSLErrors;
+        this.jvmOptions = jvmOptions;
 
         this.setNumExecutors(numExecutors);
     }
@@ -112,6 +114,10 @@ public class OrkaAgent extends AbstractCloudSlave {
 
     public int getNumCPUs() {
         return this.numCPUs;
+    }
+
+    public String getJvmOptions() {
+        return this.jvmOptions;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
@@ -46,6 +46,17 @@ public class OrkaAgent extends AbstractCloudSlave {
         this(name, orkaCredentialsId, orkaEndpoint, vmCredentialsId, vm, node, redirectHost, createNewVMConfig,
                 configName, baseImage, numCPUs, numExecutors, host, port, remoteFS, false, false, null);
     }
+
+    public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId, String vm,
+            String node, String redirectHost, boolean createNewVMConfig, String configName, String baseImage,
+            int numCPUs, int numExecutors, String host, int port, String remoteFS,
+            boolean useJenkinsProxySettings, boolean ignoreSSLErrors)
+            throws Descriptor.FormException, IOException {
+
+        this(name, orkaCredentialsId, orkaEndpoint, vmCredentialsId, vm, node, redirectHost, createNewVMConfig,
+                configName, baseImage, numCPUs, numExecutors, host, port, remoteFS, 
+                useJenkinsProxySettings, ignoreSSLErrors, null);
+    }
     
     @DataBoundConstructor
     public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId, String vm,

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -37,11 +37,13 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
     private transient String redirectHost;
     private String host;
     private int port;
+    private String jvmOptions;
 
-    public OrkaComputerLauncher(String host, int port, String redirectHost) {
+    public OrkaComputerLauncher(String host, int port, String redirectHost, String jvmOptions) {
         this.host = host;
         this.port = port;
         this.redirectHost = redirectHost;
+        this.jvmOptions = jvmOptions;
     }
 
     public String getHost() {
@@ -50,6 +52,10 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
 
     public int getPort() {
         return this.port;
+    }
+
+    public String getJvmOptions() {
+        return this.jvmOptions;
     }
 
     @Override
@@ -151,12 +157,11 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
     }
 
     private SSHLauncher getLauncher(String vmCredentialsId) {
-        String jvmOptions = null;
         String javaPath = null;
         String prefixStartSlaveCmd = null;
         String suffixStartSlaveCmd = null;
 
-        return new SSHLauncher(this.host, this.port, vmCredentialsId, jvmOptions, javaPath, prefixStartSlaveCmd,
+        return new SSHLauncher(this.host, this.port, vmCredentialsId, this.jvmOptions, javaPath, prefixStartSlaveCmd,
                 suffixStartSlaveCmd, this.launchTimeoutSeconds, this.maxRetries, this.retryWaitTime,
                 new NonVerifyingKeyVerificationStrategy());
     }

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -39,6 +39,10 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
     private int port;
     private String jvmOptions;
 
+    public OrkaComputerLauncher(String host, int port, String redirectHost) {
+        this(host, port, redirectHost, null);
+    }
+
     public OrkaComputerLauncher(String host, int port, String redirectHost, String jvmOptions) {
         this.host = host;
         this.port = port;

--- a/src/main/java/io/jenkins/plugins/orka/OrkaProvisionedAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaProvisionedAgent.java
@@ -39,16 +39,18 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
     private String vmCredentialsId;
     private String namePrefix;
     private OrkaVerificationStrategy verificationStrategy;
+    private String jvmOptions;
 
     @DataBoundConstructor
     public OrkaProvisionedAgent(String cloudId, String namePrefix, String vmId, String node, String host, int sshPort,
             String vmCredentialsId, int numExecutors, String remoteFS, Mode mode, String labelString, 
             RetentionStrategy<?> retentionStrategy, 
-            OrkaVerificationStrategy verificationStrategy, List<? extends NodeProperty<?>> nodeProperties)
+            OrkaVerificationStrategy verificationStrategy, List<? extends NodeProperty<?>> nodeProperties,
+            String jvmOptions)
             throws Descriptor.FormException, IOException {
 
         super(StringUtils.isNotBlank(namePrefix) ? namePrefix + '_' + vmId : vmId, remoteFS, 
-                new WaitSSHLauncher(host, sshPort, vmCredentialsId, verificationStrategy));
+                new WaitSSHLauncher(host, sshPort, vmCredentialsId, verificationStrategy, jvmOptions));
 
         this.setNumExecutors(numExecutors);
         this.setMode(mode);
@@ -69,6 +71,7 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
         this.vmCredentialsId = vmCredentialsId;
         this.namePrefix = namePrefix;
         this.verificationStrategy = verificationStrategy;
+        this.jvmOptions = jvmOptions;
     }
 
     protected Object readResolve() {
@@ -104,6 +107,10 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
 
     public String getNamePrefix() {
         return this.namePrefix;
+    }
+    
+    public String getJvmOptions() {
+        return this.jvmOptions;
     }
 
     public OrkaVerificationStrategy getVerificationStrategy() {

--- a/src/main/java/io/jenkins/plugins/orka/OrkaProvisionedAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaProvisionedAgent.java
@@ -41,6 +41,15 @@ public class OrkaProvisionedAgent extends AbstractCloudSlave {
     private OrkaVerificationStrategy verificationStrategy;
     private String jvmOptions;
 
+    public OrkaProvisionedAgent(String cloudId, String namePrefix, String vmId, String node, String host, int sshPort,
+            String vmCredentialsId, int numExecutors, String remoteFS, Mode mode, String labelString, 
+            RetentionStrategy<?> retentionStrategy, 
+            OrkaVerificationStrategy verificationStrategy, List<? extends NodeProperty<?>> nodeProperties)
+            throws Descriptor.FormException, IOException {
+        this(cloudId, namePrefix, vmId, node, host, sshPort, vmCredentialsId, numExecutors,
+                remoteFS, mode, labelString, retentionStrategy, verificationStrategy, nodeProperties, null);
+    }
+
     @DataBoundConstructor
     public OrkaProvisionedAgent(String cloudId, String namePrefix, String vmId, String node, String host, int sshPort,
             String vmCredentialsId, int numExecutors, String remoteFS, Mode mode, String labelString, 

--- a/src/main/java/io/jenkins/plugins/orka/WaitSSHLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/WaitSSHLauncher.java
@@ -18,8 +18,7 @@ public final class WaitSSHLauncher extends ComputerLauncher {
     private OrkaVerificationStrategy verificationStrategy;
 
     public WaitSSHLauncher(String host, int sshPort, String vmCredentialsId,
-            OrkaVerificationStrategy verificationStrategy) {
-        String jvmOptions = null;
+            OrkaVerificationStrategy verificationStrategy, String jvmOptions) {
         String javaPath = null;
         String prefixStartSlaveCmd = null;
         String suffixStartSlaveCmd = null;

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -62,6 +62,10 @@
 
       <f:slave-mode name="mode" node="${instance}"/>
 
+       <f:entry title="${%JVM options for the Orka agent process}" field="jvmOptions">
+        <f:textbox/>
+      </f:entry>
+
       <f:advanced>
         <f:dropdownDescriptorSelector title="${%Verification Strategy}" field="verificationStrategy" descriptors="${descriptor.getVerificationStrategyDescriptors()}" default="${descriptor.getDefaultVerificationDescriptor()}" />
       </f:advanced>

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -62,7 +62,7 @@
 
       <f:slave-mode name="mode" node="${instance}"/>
 
-       <f:entry title="${%JVM options for the Orka agent process}" field="jvmOptions">
+      <f:entry title="${%JVM options for the Orka agent process}" field="jvmOptions">
         <f:textbox/>
       </f:entry>
 

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -75,6 +75,10 @@
 
     <f:slave-mode name="mode" node="${instance}"/>
 
+    <f:entry title="${%JVM options for the Orka agent process}" field="jvmOptions">
+        <f:textbox/>
+    </f:entry>
+
     <j:if test="${h.getRetentionStrategyDescriptors().size() gt 1}">
         <f:dropdownList name="slave.retentionStrategy" title="${%Availability}"
                         help="/help/system-config/master-slave/availability.html">

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaComputer/configure.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaComputer/configure.jelly
@@ -67,6 +67,10 @@
 
           <f:slave-mode name="mode" node="${instance}"/>
 
+          <f:entry title="${%JVM options for the Orka agent process}" field="jvmOptions">
+            <f:textbox/>
+          </f:entry>
+
           <j:if test="${h.getRetentionStrategyDescriptors().size() gt 1}">
             <f:dropdownList name="slave.retentionStrategy" title="${%Availability}"
                             help="/help/system-config/master-slave/availability.html">

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaProvisionedAgent/configure-entries.jelly
@@ -49,6 +49,10 @@
 
     <f:slave-mode name="mode" node="${instance}"/>
 
+    <f:entry title="${%JVM options for the Orka agent process}" field="jvmOptions">
+      <f:textbox/>
+    </f:entry>
+
     <f:dropdownList name="retentionStrategy" title="${%Retention Strategy}" help="${descriptor.getHelpFile('retentionStrategy')}">
       <j:forEach var="d" items="${descriptor.getRetentionStrategyDescriptors()}">
         <f:dropdownListBlock value="${d.clazz.name}" name="${d.displayName}"


### PR DESCRIPTION
This PR adds an ability for the users to provide JVM options for both ephemeral and permanent Orka Jenkins agents.