### PR TITLE
OK-521  - Introduce configurable http timeout for non-deployment operations

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -106,7 +106,7 @@ public class OrkaCloud extends Cloud {
         this.capacityHandler = new CapacityHandler(this.name, this.instanceCap);
 
         this.timeout = this.timeout > 0 ? this.timeout : defaultTimeout;
-        this.httpTimeout = this.httpTimeout > 0 ? this.timeout : defaultHttpTimeout;
+        this.httpTimeout = this.httpTimeout > 0 ? this.httpTimeout : defaultHttpTimeout;
 
         return this;
     }

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -44,14 +44,14 @@ public class OrkaCloud extends Cloud {
     private static final Logger logger = Logger.getLogger(OrkaCloud.class.getName());
     private static final int recommendedMinTimeout = 30;
     private static final int defaultTimeout = 600;
-    private static final int defaultDeletionTimeout = 600;
+    private static final int defaultHttpTimeout = 600;
 
     private String credentialsId;
     private String endpoint;
     private int instanceCap;
     private String instanceCapSetting;
     private int timeout;
-    private int deletionTimeout;
+    private int httpTimeout;
     private boolean useJenkinsProxySettings;
     private boolean ignoreSSLErrors;
 
@@ -69,13 +69,13 @@ public class OrkaCloud extends Cloud {
     public OrkaCloud(String name, String credentialsId, String endpoint, String instanceCapSetting, int timeout,
         boolean useJenkinsProxySettings, boolean ignoreSSLErrors, List<? extends AddressMapper> mappings,
         List<? extends AgentTemplate> templates) {
-        this(name, credentialsId, endpoint, instanceCapSetting, timeout, defaultDeletionTimeout,
+        this(name, credentialsId, endpoint, instanceCapSetting, timeout, defaultHttpTimeout,
             useJenkinsProxySettings, ignoreSSLErrors, mappings, templates);
     }
 
     @DataBoundConstructor
     public OrkaCloud(String name, String credentialsId, String endpoint, String instanceCapSetting, int timeout,
-        int deletionTimeout, boolean useJenkinsProxySettings, boolean ignoreSSLErrors,
+        int httpTimeout, boolean useJenkinsProxySettings, boolean ignoreSSLErrors,
         List<? extends AddressMapper> mappings, List<? extends AgentTemplate> templates) {
         super(name);
 
@@ -83,7 +83,7 @@ public class OrkaCloud extends Cloud {
         this.endpoint = endpoint;
         this.instanceCapSetting = instanceCapSetting;
         this.timeout = timeout;
-        this.deletionTimeout = deletionTimeout;
+        this.httpTimeout = httpTimeout;
         this.useJenkinsProxySettings = useJenkinsProxySettings;
         this.ignoreSSLErrors = ignoreSSLErrors;
 
@@ -106,7 +106,7 @@ public class OrkaCloud extends Cloud {
         this.capacityHandler = new CapacityHandler(this.name, this.instanceCap);
 
         this.timeout = this.timeout > 0 ? this.timeout : defaultTimeout;
-        this.deletionTimeout = this.deletionTimeout > 0 ? this.timeout : defaultDeletionTimeout;
+        this.httpTimeout = this.httpTimeout > 0 ? this.timeout : defaultHttpTimeout;
 
         return this;
     }
@@ -135,8 +135,8 @@ public class OrkaCloud extends Cloud {
         return this.timeout;
     }
 
-    public int getDeletionTimeout() {
-        return this.deletionTimeout;
+    public int getHttpTimeout() {
+        return this.httpTimeout;
     }
 
     public List<? extends AddressMapper> getMappings() {
@@ -159,14 +159,14 @@ public class OrkaCloud extends Cloud {
 
     public List<OrkaVM> getVMs() throws IOException {
         return new OrkaClientProxyFactory()
-                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
+                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.httpTimeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
                 .getVMs();
     }
 
     public List<OrkaVMConfig> getVMConfigs() throws IOException {
         return new OrkaClientProxyFactory()
-                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
+                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.httpTimeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
                 .getVMConfigs();
     }
@@ -174,7 +174,7 @@ public class OrkaCloud extends Cloud {
     public ConfigurationResponse createConfiguration(String name, String image, String baseImage, String configTemplate,
             int cpuCount) throws IOException {
         return new OrkaClientProxyFactory()
-                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
+                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.httpTimeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
                 .createConfiguration(name, image, baseImage, configTemplate, cpuCount);
     }
@@ -189,7 +189,7 @@ public class OrkaCloud extends Cloud {
     public void deleteVM(String name) throws IOException {
         try {
             DeletionResponse deletionResponse = new OrkaClientProxyFactory().getOrkaClientProxy(this.endpoint,
-                this.credentialsId, this.deletionTimeout, this.useJenkinsProxySettings,this.ignoreSSLErrors)
+                this.credentialsId, this.httpTimeout, this.useJenkinsProxySettings,this.ignoreSSLErrors)
                 .deleteVM(name);
 
             if (deletionResponse.isSuccessful()) {
@@ -297,8 +297,8 @@ public class OrkaCloud extends Cloud {
             return defaultTimeout;
         }
 
-        public int getDefaultDeletionTimeout() {
-            return defaultDeletionTimeout;
+        public int getDefaultHttpTimeout() {
+            return defaultHttpTimeout;
         }
 
         public ListBoxModel doFillCredentialsIdItems() {
@@ -323,7 +323,7 @@ public class OrkaCloud extends Cloud {
             }
         }
 
-        public FormValidation doCheckDeletionTimeout(@QueryParameter String value) {
+        public FormValidation doCheckHttpTimeout(@QueryParameter String value) {
             try {
                 int timeoutValue = Integer.parseInt(value);
                 if (0 < timeoutValue && timeoutValue < recommendedMinTimeout) {

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -44,7 +44,7 @@ public class OrkaCloud extends Cloud {
     private static final Logger logger = Logger.getLogger(OrkaCloud.class.getName());
     private static final int recommendedMinTimeout = 30;
     private static final int defaultTimeout = 600;
-    private static final int defaultHttpTimeout = 600;
+    private static final int defaultHttpTimeout = 300;
 
     private String credentialsId;
     private String endpoint;
@@ -328,16 +328,16 @@ public class OrkaCloud extends Cloud {
                 int timeoutValue = Integer.parseInt(value);
                 if (0 < timeoutValue && timeoutValue < recommendedMinTimeout) {
                     return FormValidation.warning(String.format(
-                                "Deletion timeout less than %d seconds is not recommended.", recommendedMinTimeout));
+                                "HTTP timeout less than %d seconds is not recommended.", recommendedMinTimeout));
                 }
 
                 if (timeoutValue <= 0) {
-                    return FormValidation.error("Deletion timeout must be a positive number.");
+                    return FormValidation.error("HTTP timeout must be a positive number.");
                 }
 
                 return FormValidation.ok();
             } catch (NumberFormatException e) {
-                return FormValidation.error("Deletion timeout must be a number.");
+                return FormValidation.error("HTTP timeout must be a number.");
             }
         }
 

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -174,7 +174,7 @@ public class OrkaCloud extends Cloud {
     public void deleteVM(String name) throws IOException {
         try {
             DeletionResponse deletionResponse = new OrkaClientProxyFactory().getOrkaClientProxy(this.endpoint, 
-                this.credentialsId, this.useJenkinsProxySettings,this.ignoreSSLErrors)
+                this.credentialsId, this.timeout, this.useJenkinsProxySettings,this.ignoreSSLErrors)
                 .deleteVM(name);
     
             if (deletionResponse.isSuccessful()) {

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -44,19 +44,21 @@ public class OrkaCloud extends Cloud {
     private static final Logger logger = Logger.getLogger(OrkaCloud.class.getName());
     private static final int recommendedMinTimeout = 30;
     private static final int defaultTimeout = 600;
+    private static final int defaultDeletionTimeout = 600;
 
     private String credentialsId;
     private String endpoint;
     private int instanceCap;
     private String instanceCapSetting;
     private int timeout;
+    private int deletionTimeout;
     private boolean useJenkinsProxySettings;
     private boolean ignoreSSLErrors;
 
     private List<? extends AddressMapper> mappings;
     private final List<? extends AgentTemplate> templates;
     private transient CapacityHandler capacityHandler;
-    
+
     public OrkaCloud(String name, String credentialsId, String endpoint, String instanceCapSetting, int timeout,
             boolean useJenkinsProxySettings, List<? extends AddressMapper> mappings,
             List<? extends AgentTemplate> templates) {
@@ -64,16 +66,24 @@ public class OrkaCloud extends Cloud {
                 templates);
     }
 
+    public OrkaCloud(String name, String credentialsId, String endpoint, String instanceCapSetting, int timeout,
+        boolean useJenkinsProxySettings, boolean ignoreSSLErrors, List<? extends AddressMapper> mappings,
+        List<? extends AgentTemplate> templates) {
+        this(name, credentialsId, endpoint, instanceCapSetting, timeout, defaultDeletionTimeout,
+            useJenkinsProxySettings, ignoreSSLErrors, mappings, templates);
+    }
+
     @DataBoundConstructor
     public OrkaCloud(String name, String credentialsId, String endpoint, String instanceCapSetting, int timeout,
-            boolean useJenkinsProxySettings, boolean ignoreSSLErrors, List<? extends AddressMapper> mappings,
-            List<? extends AgentTemplate> templates) {
+        int deletionTimeout, boolean useJenkinsProxySettings, boolean ignoreSSLErrors,
+        List<? extends AddressMapper> mappings, List<? extends AgentTemplate> templates) {
         super(name);
 
         this.credentialsId = credentialsId;
         this.endpoint = endpoint;
         this.instanceCapSetting = instanceCapSetting;
         this.timeout = timeout;
+        this.deletionTimeout = deletionTimeout;
         this.useJenkinsProxySettings = useJenkinsProxySettings;
         this.ignoreSSLErrors = ignoreSSLErrors;
 
@@ -96,6 +106,7 @@ public class OrkaCloud extends Cloud {
         this.capacityHandler = new CapacityHandler(this.name, this.instanceCap);
 
         this.timeout = this.timeout > 0 ? this.timeout : defaultTimeout;
+        this.deletionTimeout = this.deletionTimeout > 0 ? this.timeout : defaultDeletionTimeout;
 
         return this;
     }
@@ -111,7 +122,7 @@ public class OrkaCloud extends Cloud {
     public boolean getUseJenkinsProxySettings() {
         return this.useJenkinsProxySettings;
     }
-    
+
     public boolean getIgnoreSSLErrors() {
         return this.ignoreSSLErrors;
     }
@@ -122,6 +133,10 @@ public class OrkaCloud extends Cloud {
 
     public int getTimeout() {
         return this.timeout;
+    }
+
+    public int getDeletionTimeout() {
+        return this.deletionTimeout;
     }
 
     public List<? extends AddressMapper> getMappings() {
@@ -144,14 +159,14 @@ public class OrkaCloud extends Cloud {
 
     public List<OrkaVM> getVMs() throws IOException {
         return new OrkaClientProxyFactory()
-                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.useJenkinsProxySettings, 
+                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
                 .getVMs();
     }
-    
+
     public List<OrkaVMConfig> getVMConfigs() throws IOException {
         return new OrkaClientProxyFactory()
-                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.useJenkinsProxySettings, 
+                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
                 .getVMConfigs();
     }
@@ -159,24 +174,24 @@ public class OrkaCloud extends Cloud {
     public ConfigurationResponse createConfiguration(String name, String image, String baseImage, String configTemplate,
             int cpuCount) throws IOException {
         return new OrkaClientProxyFactory()
-                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.useJenkinsProxySettings, 
+                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
                 .createConfiguration(name, image, baseImage, configTemplate, cpuCount);
     }
 
     public DeploymentResponse deployVM(String name) throws IOException {
         return new OrkaClientProxyFactory()
-                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings, 
+                .getOrkaClientProxy(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
                 .deployVM(name);
     }
 
     public void deleteVM(String name) throws IOException {
         try {
-            DeletionResponse deletionResponse = new OrkaClientProxyFactory().getOrkaClientProxy(this.endpoint, 
-                this.credentialsId, this.timeout, this.useJenkinsProxySettings,this.ignoreSSLErrors)
+            DeletionResponse deletionResponse = new OrkaClientProxyFactory().getOrkaClientProxy(this.endpoint,
+                this.credentialsId, this.deletionTimeout, this.useJenkinsProxySettings,this.ignoreSSLErrors)
                 .deleteVM(name);
-    
+
             if (deletionResponse.isSuccessful()) {
                 logger.info("VM " + name + " is successfully deleted.");
                 this.capacityHandler.removeRunningInstance();
@@ -282,6 +297,10 @@ public class OrkaCloud extends Cloud {
             return defaultTimeout;
         }
 
+        public int getDefaultDeletionTimeout() {
+            return defaultDeletionTimeout;
+        }
+
         public ListBoxModel doFillCredentialsIdItems() {
             return CredentialsHelper.getCredentials(StandardCredentials.class);
         }
@@ -304,9 +323,27 @@ public class OrkaCloud extends Cloud {
             }
         }
 
+        public FormValidation doCheckDeletionTimeout(@QueryParameter String value) {
+            try {
+                int timeoutValue = Integer.parseInt(value);
+                if (0 < timeoutValue && timeoutValue < recommendedMinTimeout) {
+                    return FormValidation.warning(String.format(
+                                "Deletion timeout less than %d seconds is not recommended.", recommendedMinTimeout));
+                }
+
+                if (timeoutValue <= 0) {
+                    return FormValidation.error("Deletion timeout must be a positive number.");
+                }
+
+                return FormValidation.ok();
+            } catch (NumberFormatException e) {
+                return FormValidation.error("Deletion timeout must be a number.");
+            }
+        }
+
         @POST
         public FormValidation doTestConnection(@QueryParameter String credentialsId, @QueryParameter String endpoint,
-                @QueryParameter boolean useJenkinsProxySettings, 
+                @QueryParameter boolean useJenkinsProxySettings,
                 @QueryParameter boolean ignoreSSLErrors) throws IOException {
 
             return this.formValidator.doTestConnection(credentialsId, endpoint, useJenkinsProxySettings,

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/config.jelly
@@ -22,8 +22,8 @@
       <f:entry title="Deployment Timeout (sec)" field="timeout">
           <f:number default="${descriptor.getDefaultTimeout()}"/>
       </f:entry>
-      <f:entry title="Deletion Timeout (sec)" field="deletion">
-          <f:number default="${descriptor.getDefaultDeletionTimeout()}"/>
+      <f:entry title="HTTP Timeout (sec)" field="httpTimeout">
+          <f:number default="${descriptor.getDefaultHttpTimeout()}"/>
       </f:entry>
       <f:entry title="${%Node Mappings}" description="${%List of Orka node mappings}">
           <f:repeatable field="mappings" header="${%Mapping}" add="${%Add mapping}">

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/config.jelly
@@ -22,6 +22,9 @@
       <f:entry title="Deployment Timeout (sec)" field="timeout">
           <f:number default="${descriptor.getDefaultTimeout()}"/>
       </f:entry>
+      <f:entry title="Deletion Timeout (sec)" field="deletion">
+          <f:number default="${descriptor.getDefaultDeletionTimeout()}"/>
+      </f:entry>
       <f:entry title="${%Node Mappings}" description="${%List of Orka node mappings}">
           <f:repeatable field="mappings" header="${%Mapping}" add="${%Add mapping}">
               <st:include page="config.jelly" class="${descriptor.clazz}"/>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-deletionTimeout.html
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-deletionTimeout.html
@@ -1,0 +1,1 @@
+<div>The time after which the request for deleting an Orka VM will timeout. Defaults to 600 seconds (10 minutes).</div>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-deletionTimeout.html
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-deletionTimeout.html
@@ -1,1 +1,0 @@
-<div>The time after which the request for deleting an Orka VM will timeout. Defaults to 600 seconds (10 minutes).</div>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-httpTimeout.html
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-httpTimeout.html
@@ -1,0 +1,1 @@
+<div>The time after which the request to the Orka API will timeout. Defaults to 600 seconds (10 minutes).</div>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-httpTimeout.html
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-httpTimeout.html
@@ -1,1 +1,1 @@
-<div>The time after which the request to the Orka API will timeout. This timeout is used for all HTTP operations but <b>deploy</b>. Defaults to 300 seconds (5 minutes).</div>
+<div>The time after which the request to the Orka API timeouts. This timeout is used for all HTTP operations but <b>deploy</b>. Defaults to 300 seconds (5 minutes).</div>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-httpTimeout.html
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaCloud/help-httpTimeout.html
@@ -1,1 +1,1 @@
-<div>The time after which the request to the Orka API will timeout. Defaults to 600 seconds (10 minutes).</div>
+<div>The time after which the request to the Orka API will timeout. This timeout is used for all HTTP operations but <b>deploy</b>. Defaults to 300 seconds (5 minutes).</div>


### PR DESCRIPTION
Introduce configuration option to set http timeout for all requests made to the Orka API except deploy - it has it's own configuration option for deploy timeout.