### PR TITLE
Take advantage of Orka API new token algorithm

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/OrkaVersionMonitor.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaVersionMonitor.java
@@ -1,0 +1,52 @@
+package io.jenkins.plugins.orka;
+
+import hudson.Extension;
+import hudson.model.AsyncPeriodicWork;
+import hudson.model.TaskListener;
+import hudson.slaves.Cloud;
+import io.jenkins.plugins.orka.client.HealthCheckResponse;
+import io.jenkins.plugins.orka.helpers.OrkaClientProxyFactory;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
+
+@Extension
+public class OrkaVersionMonitor extends AsyncPeriodicWork {
+    private static final Logger logger = Logger.getLogger(OrkaVersionMonitor.class.getName());
+    OrkaClientProxyFactory clientFactory = new OrkaClientProxyFactory();
+
+    public OrkaVersionMonitor() {
+        super("Orka version monitor");
+    }
+
+    @Override
+    public long getRecurrencePeriod() {
+        return TimeUnit.HOURS.toMillis(1);
+    }
+
+    @Override
+    protected void execute(TaskListener listener) throws IOException, InterruptedException {
+        logger.fine("Running Orka version monitor");
+
+        Jenkins jenkinsInstance = Jenkins.get();
+        for (Cloud cloud : jenkinsInstance.clouds) {
+            if ((cloud instanceof OrkaCloud)) {
+                OrkaCloud orka = (OrkaCloud) cloud;
+                try {
+                    HealthCheckResponse healthCheck = clientFactory
+                            .getOrkaClientProxy(orka.getEndpoint(), orka.getCredentialsId(), orka.getHttpTimeout(),
+                                    orka.getUseJenkinsProxySettings(), orka.getIgnoreSSLErrors())
+                            .getHealthCheck();
+
+                    logger.fine("Server: " + orka.getEndpoint() + ". Version: " + healthCheck.getApiVersion());
+                    OrkaClientProxyFactory.setServerVersion(orka.getEndpoint(), healthCheck.getApiVersion());
+                } catch (Exception e) {
+                    logger.warning("Error while getting Orka version: " + e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/client/HealthCheckResponse.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/HealthCheckResponse.java
@@ -1,0 +1,17 @@
+package io.jenkins.plugins.orka.client;
+
+import com.google.gson.annotations.SerializedName;
+
+public class HealthCheckResponse extends ResponseBase {
+    @SerializedName("api_version")
+    private String apiVersion;
+
+    public HealthCheckResponse(String apiVersion, String message, OrkaError[] errors) {
+        super(message, errors);
+        this.apiVersion = apiVersion;
+    }
+
+    public String getApiVersion() {
+        return this.apiVersion;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClientV2.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClientV2.java
@@ -1,0 +1,86 @@
+package io.jenkins.plugins.orka.client;
+
+import java.io.IOException;
+import java.net.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import okhttp3.Request;
+
+import org.apache.commons.lang.StringUtils;
+
+public class OrkaClientV2 extends OrkaClient {
+    private static final int HTTP_UNAUTHORIZED = 401;
+    private static final Logger logger = Logger.getLogger(OrkaClientV2.class.getName());
+    private static final Map<String, TokenResponse> tokens = new HashMap<String, TokenResponse>();
+
+    private String email;
+    private String password;
+
+    public OrkaClientV2(String endpoint, String email, String password) throws IOException {
+        this(endpoint, email, password, defaultHttpClientTimeout, Proxy.NO_PROXY);
+    }
+
+    public OrkaClientV2(String endpoint, String email, String password, int httpClientTimeout, Proxy proxy)
+            throws IOException {
+        this(endpoint, email, password, httpClientTimeout, proxy, false);
+    }
+
+    public OrkaClientV2(String endpoint, String email, String password, int httpClientTimeout, Proxy proxy,
+            boolean ignoreSSLErrors)
+            throws IOException {
+        super(endpoint, email, password, httpClientTimeout, proxy, ignoreSSLErrors);
+        this.email = email;
+        this.password = password;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    @Override
+    TokenResponse getToken() {
+        return tokens.containsKey(this.email) ? tokens.get(this.email) : null;
+    }
+
+    private void setToken(String email, TokenResponse token) {
+        tokens.put(email, token);
+    }
+
+    @Override
+    protected void initToken(String email, String password) throws IOException {
+        if (!tokens.containsKey(email) || tokens.get(email) == null) {
+            this.initTokenImpl(email, password);
+        }
+    }
+
+    private void initTokenImpl(String email, String password) throws IOException {
+        TokenResponse tokenResponse = this.createToken(email, password);
+        this.verifyToken(tokenResponse);
+        this.setToken(email, tokenResponse);
+    }
+
+    @Override
+    protected HttpResponse executeCall(Request request) throws IOException {
+        HttpResponse response = executeCallImpl(request);
+
+        String requestPath = request.url().url().getPath();
+        if (response.getCode() == HTTP_UNAUTHORIZED && requestPath != TOKEN_PATH
+                && StringUtils.isNotBlank(response.getBody()) && response.getBody().contains("revoked")) {
+            logger.fine("Token was revoked. Create new token...");
+
+            this.initTokenImpl(this.email, this.password);
+            TokenResponse newToken = this.getToken();
+
+            logger.fine("Retrying request with new token...");
+            Request newRequest = request.newBuilder()
+                    .removeHeader(AUTHORIZATION_HEADER)
+                    .addHeader(AUTHORIZATION_HEADER, BEARER + newToken.getToken()).build();
+
+            response = executeCallImpl(newRequest);
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.orka.helpers;
 
 import hudson.util.FormValidation;
+import io.jenkins.plugins.orka.client.HealthCheckResponse;
 import io.jenkins.plugins.orka.client.OrkaNode;
 import io.jenkins.plugins.orka.client.TokenStatusResponse;
 
@@ -116,11 +117,11 @@ public class FormValidator {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         try {
-            TokenStatusResponse response = new OrkaClientProxyFactory()
+            HealthCheckResponse response = new OrkaClientProxyFactory()
                     .getOrkaClientProxy(endpoint, credentialsId, useJenkinsProxySettings,
                             ignoreSSLErrors)
-                    .getTokenStatus();
-            if (!response.isSuccessful() || !response.getIsValid()) {
+                    .getHealthCheck();
+            if (!response.isSuccessful()) {
                 return failedConnection(Utils.getErrorMessage(response));
             }
         } catch (IOException e) {

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
@@ -8,11 +8,12 @@ import hudson.util.Secret;
 import io.jenkins.plugins.orka.client.ConfigurationResponse;
 import io.jenkins.plugins.orka.client.DeletionResponse;
 import io.jenkins.plugins.orka.client.DeploymentResponse;
+import io.jenkins.plugins.orka.client.HealthCheckResponse;
 import io.jenkins.plugins.orka.client.OrkaClient;
+import io.jenkins.plugins.orka.client.OrkaClientV2;
 import io.jenkins.plugins.orka.client.OrkaNode;
 import io.jenkins.plugins.orka.client.OrkaVM;
 import io.jenkins.plugins.orka.client.OrkaVMConfig;
-import io.jenkins.plugins.orka.client.TokenStatusResponse;
 
 import java.io.IOException;
 import java.net.Proxy;
@@ -20,12 +21,16 @@ import java.util.List;
 
 import jenkins.model.Jenkins;
 
+import org.apache.commons.lang.StringUtils;
+
 public class OrkaClientProxy {
+    private static String firstVersionWithSingleToken = "2.1.1";
     private StandardUsernamePasswordCredentials credentials;
     private String endpoint;
     private int httpClientTimeout;
     private boolean ignoreSSLErrors;
     private Proxy proxy;
+    private String serverVersion;
 
     public OrkaClientProxy(String endpoint, String credentialsId, int httpClientTimeout,
             boolean useJenkinsProxySettings) {
@@ -34,11 +39,17 @@ public class OrkaClientProxy {
 
     public OrkaClientProxy(String endpoint, String credentialsId, int httpClientTimeout,
             boolean useJenkinsProxySettings, boolean ignoreSSLErrors) {
+        this(endpoint, credentialsId, httpClientTimeout, useJenkinsProxySettings, ignoreSSLErrors, null);
+    }
+
+    public OrkaClientProxy(String endpoint, String credentialsId, int httpClientTimeout,
+            boolean useJenkinsProxySettings, boolean ignoreSSLErrors, String serverVersion) {
         this.credentials = CredentialsHelper.lookupSystemCredentials(credentialsId);
         this.endpoint = endpoint;
         this.httpClientTimeout = httpClientTimeout;
         this.proxy = this.getProxy(useJenkinsProxySettings);
         this.ignoreSSLErrors = ignoreSSLErrors;
+        this.serverVersion = serverVersion;
     }
 
     public List<OrkaVM> getVMs() throws IOException {
@@ -109,14 +120,23 @@ public class OrkaClientProxy {
         }
     }
 
-    public TokenStatusResponse getTokenStatus() throws IOException {
+    public HealthCheckResponse getHealthCheck() throws IOException {
         try (OrkaClient client = getOrkaClient()) {
-            return client.getTokenStatus();
+            return client.getHealthCheck();
         }
     }
 
     private OrkaClient getOrkaClient() throws IOException {
-        return new OrkaClient(this.endpoint, this.credentials.getUsername(), Secret.toString(credentials.getPassword()),
+        if (StringUtils.isBlank(this.serverVersion)
+                || Utils.compareVersions(this.serverVersion, firstVersionWithSingleToken) < 0) {
+
+            return new OrkaClient(this.endpoint, this.credentials.getUsername(),
+                    Secret.toString(credentials.getPassword()),
+                    this.httpClientTimeout, this.proxy, this.ignoreSSLErrors);
+        }
+
+        return new OrkaClientV2(this.endpoint, this.credentials.getUsername(),
+                Secret.toString(credentials.getPassword()),
                 this.httpClientTimeout, this.proxy, this.ignoreSSLErrors);
     }
 

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxyFactory.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxyFactory.java
@@ -2,8 +2,16 @@
 package io.jenkins.plugins.orka.helpers;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class OrkaClientProxyFactory {
+    private static Map<String, String> endpointToVersion = new HashMap<String, String>();
+
+    public static void setServerVersion(String endpoint, String version) {
+        endpointToVersion.put(endpoint, version);
+    }
+
     public OrkaClientProxy getOrkaClientProxy(String endpoint, String credentialsId, boolean useJenkinsProxySettings)
             throws IOException {
         return this.getOrkaClientProxy(endpoint, credentialsId, useJenkinsProxySettings, false);
@@ -24,6 +32,6 @@ public class OrkaClientProxyFactory {
     public OrkaClientProxy getOrkaClientProxy(String endpoint, String credentialsId, int httpClientTimeout,
             boolean useJenkinsProxySettings, boolean ignoreSSLErrors) throws IOException {
         return new OrkaClientProxy(endpoint, credentialsId, httpClientTimeout, useJenkinsProxySettings,
-                ignoreSSLErrors);
+                ignoreSSLErrors, endpointToVersion.get(endpoint));
     }
 }

--- a/src/main/java/io/jenkins/plugins/orka/helpers/Utils.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/Utils.java
@@ -6,7 +6,6 @@ import io.jenkins.plugins.orka.client.ResponseBase;
 
 import java.util.Date;
 
-
 public class Utils {
     public static String getTimestamp() {
         return String.format("[%1$tD %1$tT]", new Date());
@@ -28,10 +27,37 @@ public class Utils {
             if (idleMinutesValue <= 0) {
                 return FormValidation.error("Idle timeout must be a positive number.");
             }
-            
+
             return FormValidation.ok();
         } catch (NumberFormatException e) {
             return FormValidation.error("Idle timeout must be a positive number.");
         }
+    }
+
+    public static int compareVersions(String firstVersion, String secondVersion) {
+        String firstVersionWithoutPreview = firstVersion.split("-")[0].replace(".", "");
+        String secondVersionWithoutPreview = secondVersion.split("-")[0].replace(".", "");
+
+        firstVersionWithoutPreview = firstVersionWithoutPreview.length() == 3 ? firstVersionWithoutPreview
+                : firstVersionWithoutPreview + "0";
+        secondVersionWithoutPreview = secondVersionWithoutPreview.length() == 3 ? secondVersionWithoutPreview
+                : secondVersionWithoutPreview + "0";
+
+        Integer v1 = Integer.parseInt(firstVersionWithoutPreview);
+        Integer v2 = Integer.parseInt(secondVersionWithoutPreview);
+
+        if (v1.intValue() == v2.intValue()) {
+            Boolean isFirstVersionPreview = firstVersion.contains("-");
+            Boolean isSecondVersionPreview = secondVersion.contains("-");
+
+            if (isFirstVersionPreview && isSecondVersionPreview || !isFirstVersionPreview && !isSecondVersionPreview) {
+                return 0;
+            } else if (isFirstVersionPreview) {
+                return -1;
+            } else if (isSecondVersionPreview) {
+                return 1;
+            }
+        }
+        return v1.compareTo(v2);
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/UtilsTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/UtilsTest.java
@@ -1,0 +1,21 @@
+package io.jenkins.plugins.orka;
+
+import io.jenkins.plugins.orka.helpers.Utils;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class UtilsTest {
+    @Test
+    public void whrn_comparing_versions_should_return_correct_result() {
+        assertTrue(Utils.compareVersions("1.0.0", "1.1.2") < 0);
+        assertTrue(Utils.compareVersions("1.0.1", "1.10") < 0);
+        assertTrue(Utils.compareVersions("1.1.2", "1.0.1") > 0);
+        assertTrue(Utils.compareVersions("1.1.2", "1.2.0") < 0);
+        assertTrue(Utils.compareVersions("1.3.0", "1.3") == 0);
+        assertTrue(Utils.compareVersions("2.1.0", "2.1.1") < 0);
+        assertTrue(Utils.compareVersions("2.1.1-preview-1", "2.1.1") < 0);
+        assertTrue(Utils.compareVersions("2.1.1-preview-1", "2.1.1-preview-2") == 0);
+        assertTrue(Utils.compareVersions("2.1.1", "2.0") > 0);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/orka/client/OrkaClientTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/client/OrkaClientTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.endsWith;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,9 +30,9 @@ public class OrkaClientTest {
 
         OrkaClient client = mock(OrkaClient.class);
         when(client.post(anyString(), anyString())).thenReturn(tokenResponse);
-        when(client.getToken(anyString(), anyString())).thenCallRealMethod();
+        when(client.createToken(anyString(), anyString())).thenCallRealMethod();
 
-        String actualToken = client.getToken("email", "password").getToken();
+        String actualToken = client.createToken("email", "password").getToken();
 
         assertEquals(token, actualToken);
     }
@@ -141,7 +142,7 @@ public class OrkaClientTest {
     @Test
     public void when_calling_close_should_call_delete() throws IOException {
         OrkaClient client = mock(OrkaClient.class);
-
+        doReturn(new TokenResponse("token", "message", null)).when(client).getToken();
         doCallRealMethod().when(client).close();
 
         client.close();


### PR DESCRIPTION
Previously, the server was storing tons of tokens in a DB and we needed to revoke them to prevent DB pollution.
Now, there is a single token per user, so we no longer need to revoke them.

In addition, detect the server version and choose our approach base on that.

