### PR TITLE
OK-1116 - Allow floating point memory on vm configs

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/client/ConfigurationRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/ConfigurationRequest.java
@@ -36,7 +36,7 @@ public class ConfigurationRequest {
     private String scheduler;
 
     @SuppressFBWarnings("URF_UNREAD_FIELD")
-    private int memory;
+    private Float memory;
 
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     private String tag;
@@ -73,8 +73,12 @@ public class ConfigurationRequest {
         this.cpuCount = cpuCount;
         this.useNetBoost = useNetBoost;
         this.scheduler = StringUtils.isNotBlank(scheduler) ? scheduler : null;
-        if (!StringUtils.isBlank(memory) && !StringUtils.equals(memory, "auto") && Integer.parseInt(memory) > 0) {
-            this.memory = Integer.parseInt(memory);
+        try {
+            if (!StringUtils.isBlank(memory) && !StringUtils.equals(memory, "auto") && Float.parseFloat(memory) > 0) {
+                this.memory = Float.parseFloat(memory);
+            }
+        } catch (NumberFormatException e) {
+            // Do nothing
         }
         this.tag = StringUtils.isNotBlank(tag) && tag != null ? tag : null;
         this.tagRequired = tagRequired != null ? tagRequired : null;

--- a/src/main/java/io/jenkins/plugins/orka/client/ConfigurationRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/ConfigurationRequest.java
@@ -36,7 +36,7 @@ public class ConfigurationRequest {
     private String scheduler;
 
     @SuppressFBWarnings("URF_UNREAD_FIELD")
-    private Float memory;
+    private float memory;
 
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     private String tag;
@@ -73,12 +73,8 @@ public class ConfigurationRequest {
         this.cpuCount = cpuCount;
         this.useNetBoost = useNetBoost;
         this.scheduler = StringUtils.isNotBlank(scheduler) ? scheduler : null;
-        try {
-            if (!StringUtils.isBlank(memory) && !StringUtils.equals(memory, "auto") && Float.parseFloat(memory) > 0) {
-                this.memory = Float.parseFloat(memory);
-            }
-        } catch (NumberFormatException e) {
-            // Do nothing
+        if (!StringUtils.isBlank(memory) && !StringUtils.equals(memory, "auto") && Float.parseFloat(memory) > 0) {
+            this.memory = Float.parseFloat(memory);
         }
         this.tag = StringUtils.isNotBlank(tag) && tag != null ? tag : null;
         this.tagRequired = tagRequired != null ? tagRequired : null;

--- a/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
@@ -99,7 +99,7 @@ public class FormValidator {
             if (StringUtils.isBlank(memory) || StringUtils.equals(memory, "auto")) {
                 return FormValidation.ok();
             }
-            if (Float.parseFloat(memory) < 0) {
+            if (Float.parseFloat(memory) <= 0) {
                 return FormValidation.error("Memory should be greater than 0");
             }
             return FormValidation.ok();

--- a/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
@@ -99,7 +99,7 @@ public class FormValidator {
             if (StringUtils.isBlank(memory) || StringUtils.equals(memory, "auto")) {
                 return FormValidation.ok();
             }
-            if (Integer.parseInt(memory) < 1) {
+            if (Float.parseFloat(memory) < 0) {
                 return FormValidation.error("Memory should be greater than 0");
             }
             return FormValidation.ok();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Adds the ability to use floating point values for memory on new VM configs.

Validation - Config created through Jenkins with 5.45 G:
![image](https://user-images.githubusercontent.com/35697323/196794930-0336a11c-a7e6-4a43-b8c8-1df820820866.png)

Macstadium JIRA Issue: https://macstadium.atlassian.net/browse/OK-1116?atlOrigin=eyJpIjoiNTFiYTdkODRmYmYyNDgzYmEzOGM0NjNiNWY0NzI4NjIiLCJwIjoiaiJ9

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
