### PR TITLE
Add a configuration checkbox for controlling Net Boost

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -95,7 +95,6 @@ public class AgentTemplate implements Describable<AgentTemplate> {
                 scheduler, "auto");
     }
 
-    @DataBoundConstructor
     public AgentTemplate(String vmCredentialsId, String vm, boolean createNewVMConfig, String configName,
             String baseImage, int numCPUs, int numExecutors, String remoteFS, Mode mode, String labelString,
             String namePrefix, RetentionStrategy<?> retentionStrategy, OrkaVerificationStrategy verificationStrategy,

--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -50,6 +50,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     private String configName;
     private String baseImage;
     private int numCPUs;
+    private boolean useNetBoost;
     private String memory;
     private int numExecutors;
     private Mode mode;
@@ -92,7 +93,6 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         this(vmCredentialsId, vm, createNewVMConfig, configName, baseImage, numCPUs, numExecutors, remoteFS,
                 mode, labelString, namePrefix, retentionStrategy, verificationStrategy, nodeProperties, jvmOptions,
                 scheduler, "auto");
-
     }
 
     @DataBoundConstructor
@@ -100,12 +100,24 @@ public class AgentTemplate implements Describable<AgentTemplate> {
             String baseImage, int numCPUs, int numExecutors, String remoteFS, Mode mode, String labelString,
             String namePrefix, RetentionStrategy<?> retentionStrategy, OrkaVerificationStrategy verificationStrategy,
             List<? extends NodeProperty<?>> nodeProperties, String jvmOptions, String scheduler, String memory) {
+        this(vmCredentialsId, vm, createNewVMConfig, configName, baseImage, numCPUs, false, numExecutors, remoteFS,
+                mode, labelString, namePrefix, retentionStrategy, verificationStrategy, nodeProperties, jvmOptions,
+                scheduler, memory);
+    }
+
+    @DataBoundConstructor
+    public AgentTemplate(String vmCredentialsId, String vm, boolean createNewVMConfig, String configName,
+            String baseImage, int numCPUs, boolean useNetBoost, int numExecutors, String remoteFS, Mode mode,
+            String labelString, String namePrefix, RetentionStrategy<?> retentionStrategy,
+            OrkaVerificationStrategy verificationStrategy, List<? extends NodeProperty<?>> nodeProperties,
+            String jvmOptions, String scheduler, String memory) {
         this.vmCredentialsId = vmCredentialsId;
         this.vm = vm;
         this.createNewVMConfig = createNewVMConfig;
         this.configName = configName;
         this.baseImage = baseImage;
         this.numCPUs = numCPUs;
+        this.useNetBoost = useNetBoost;
         this.numExecutors = numExecutors;
         this.remoteFS = remoteFS;
         this.mode = mode;
@@ -149,6 +161,10 @@ public class AgentTemplate implements Describable<AgentTemplate> {
 
     public int getNumCPUs() {
         return this.numCPUs;
+    }
+
+    public boolean getUseNetBoost() {
+        return this.useNetBoost;
     }
 
     public String getMemory() {

--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -261,7 +261,7 @@ public class AgentTemplate implements Describable<AgentTemplate> {
             if (!configExist) {
                 logger.fine("Creating config with name " + this.configName);
                 return parent.createConfiguration(this.configName, this.configName, this.baseImage,
-                        Constants.DEFAULT_CONFIG_NAME, this.numCPUs, this.scheduler, this.memory);
+                        Constants.DEFAULT_CONFIG_NAME, this.numCPUs, this.useNetBoost, this.scheduler, this.memory);
             }
         }
         return null;

--- a/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
@@ -36,6 +36,7 @@ public class OrkaAgent extends AbstractCloudSlave {
     private String configName;
     private String baseImage;
     private int numCPUs;
+    private boolean useNetBoost;
     private String memory;
     private String jvmOptions;
 
@@ -70,10 +71,20 @@ public class OrkaAgent extends AbstractCloudSlave {
                 useJenkinsProxySettings, ignoreSSLErrors, jvmOptions, "auto");
     }
 
-    @DataBoundConstructor
     public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId, String vm,
             String node, String redirectHost, boolean createNewVMConfig, String configName, String baseImage,
             int numCPUs, int numExecutors, String host, int port, String remoteFS,
+            boolean useJenkinsProxySettings, boolean ignoreSSLErrors, String jvmOptions, String memory)
+            throws Descriptor.FormException, IOException {
+        this(name, orkaCredentialsId, orkaEndpoint, vmCredentialsId, vm, node, redirectHost, createNewVMConfig,
+                configName, baseImage, numCPUs, false, numExecutors, host, port, remoteFS,
+                useJenkinsProxySettings, ignoreSSLErrors, jvmOptions, "auto");
+    }
+
+    @DataBoundConstructor
+    public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId, String vm,
+            String node, String redirectHost, boolean createNewVMConfig, String configName, String baseImage,
+            int numCPUs, boolean useNetBoost, int numExecutors, String host, int port, String remoteFS,
             boolean useJenkinsProxySettings, boolean ignoreSSLErrors, String jvmOptions, String memory)
             throws Descriptor.FormException, IOException {
         super(name, remoteFS, new OrkaComputerLauncher(host, port, redirectHost, jvmOptions));
@@ -87,6 +98,7 @@ public class OrkaAgent extends AbstractCloudSlave {
         this.configName = configName;
         this.baseImage = baseImage;
         this.numCPUs = numCPUs;
+        this.useNetBoost = useNetBoost;
         this.useJenkinsProxySettings = useJenkinsProxySettings;
         this.ignoreSSLErrors = ignoreSSLErrors;
         this.jvmOptions = jvmOptions;
@@ -137,6 +149,10 @@ public class OrkaAgent extends AbstractCloudSlave {
 
     public int getNumCPUs() {
         return this.numCPUs;
+    }
+
+    public boolean getUseNetBoost() {
+        return this.useNetBoost;
     }
 
     public String getMemory() {

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -196,10 +196,15 @@ public class OrkaCloud extends Cloud {
 
     public ConfigurationResponse createConfiguration(String name, String image, String baseImage, String configTemplate,
             int cpuCount, String scheduler, String memory) throws IOException {
+        return this.createConfiguration(name, image, baseImage, configTemplate, cpuCount, false, scheduler, memory);
+    }
+
+    public ConfigurationResponse createConfiguration(String name, String image, String baseImage, String configTemplate,
+            int cpuCount, boolean useNetBoost, String scheduler, String memory) throws IOException {
         return new OrkaClientProxyFactory()
                 .getOrkaClientProxy(this.endpoint, this.credentialsId, this.httpTimeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
-                .createConfiguration(name, image, baseImage, configTemplate, cpuCount, scheduler, memory);
+                .createConfiguration(name, image, baseImage, configTemplate, cpuCount, useNetBoost, scheduler, memory);
     }
 
     public DeploymentResponse deployVM(String name) throws IOException {

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang.StringUtils;
 
 public final class OrkaComputerLauncher extends ComputerLauncher {
     private static String configurationErrorFormat = "%s: Creating configuration with configName: %s, image: %s, "
-            + "baseImage: %s, template: %s, numCPUs: %s, and memory: %s"
+            + "baseImage: %s, template: %s, numCPUs: %s, useNetBoost: %s, and memory: %s"
             + "failed with an error: %s. Stopping creation.";
     private static String deploymentErrorFormat = "%s: Deploying vm with name: %s, and node: %s"
             + "failed with an error: %s. Stopping creation.";
@@ -127,13 +127,14 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
             String image = configName;
             String baseImage = agent.getBaseImage();
             int numCPUs = agent.getNumCPUs();
+            boolean useNetBoost = agent.getUseNetBoost();
             String memory = agent.getMemory();
 
             ConfigurationResponse configResponse = clientProxy.createConfiguration(configName, image, baseImage,
-                    template, numCPUs, null, memory);
+                    template, numCPUs, useNetBoost, null, memory);
             if (!configResponse.isSuccessful()) {
                 logger.println(String.format(configurationErrorFormat, Utils.getTimestamp(), configName, image,
-                        baseImage, template, numCPUs, memory, Utils.getErrorMessage(configResponse)));
+                        baseImage, template, numCPUs, useNetBoost, memory, Utils.getErrorMessage(configResponse)));
                 return false;
             }
             logger.println(

--- a/src/main/java/io/jenkins/plugins/orka/client/ConfigurationRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/ConfigurationRequest.java
@@ -28,6 +28,10 @@ public class ConfigurationRequest {
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     private int cpuCount;
 
+    @SerializedName("net_boost")
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    private boolean useNetBoost;
+
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     private String scheduler;
 
@@ -45,11 +49,17 @@ public class ConfigurationRequest {
 
     public ConfigurationRequest(String vmName, String image, String baseImage, String configTemplate, int cpuCount,
             String scheduler, String memory) {
+        this(vmName, image, baseImage, configTemplate, cpuCount, false, scheduler, memory);
+    }
+
+    public ConfigurationRequest(String vmName, String image, String baseImage, String configTemplate, int cpuCount,
+            boolean useNetBoost, String scheduler, String memory) {
         this.vmName = vmName;
         this.image = image;
         this.baseImage = baseImage;
         this.configTemplate = configTemplate;
         this.cpuCount = cpuCount;
+        this.useNetBoost = useNetBoost;
         this.scheduler = StringUtils.isNotBlank(scheduler) ? scheduler : null;
         if (!StringUtils.isBlank(memory) && !StringUtils.equals(memory, "auto") && Integer.parseInt(memory) > 0) {
             this.memory = Integer.parseInt(memory);

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -121,9 +121,15 @@ public class OrkaClient implements AutoCloseable {
 
     public ConfigurationResponse createConfiguration(String vmName, String image, String baseImage,
             String configTemplate, int cpuCount, String scheduler, String memory) throws IOException {
+        return this.createConfiguration(vmName, image, baseImage, configTemplate, cpuCount, false, scheduler, "auto");
+    }
+
+    public ConfigurationResponse createConfiguration(
+        String vmName, String image, String baseImage, String configTemplate, int cpuCount, boolean useNetBoost,
+        String scheduler, String memory) throws IOException {
 
         ConfigurationRequest configRequest = new ConfigurationRequest(vmName, image, baseImage, configTemplate,
-                cpuCount, scheduler, memory);
+                cpuCount, useNetBoost, scheduler, memory);
 
         String configRequestJson = new Gson().toJson(configRequest);
 

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
@@ -88,9 +88,16 @@ public class OrkaClientProxy {
 
     public ConfigurationResponse createConfiguration(String vmName, String image, String baseImage,
             String configTemplate, int cpuCount, String scheduler, String memory) throws IOException {
+        return this.createConfiguration(vmName, image, baseImage, configTemplate, cpuCount, false, scheduler, memory);
+    }
 
+    public ConfigurationResponse createConfiguration(
+        String vmName, String image, String baseImage, String configTemplate, int cpuCount, boolean useNetBoost,
+        String scheduler, String memory) throws IOException {
         try (OrkaClient client = getOrkaClient()) {
-            return client.createConfiguration(vmName, image, baseImage, configTemplate, cpuCount, scheduler, memory);
+            return client.createConfiguration(
+                vmName, image, baseImage, configTemplate, cpuCount, useNetBoost, scheduler, memory
+            );
         }
     }
 

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -19,6 +19,12 @@
           <c:select />
         </f:entry>
 
+        <f:entry title="${%Use Net Boost}" field="useNetBoost" description="If checked, use Net Boost. This leads to
+          better network throughput and is required for booting Ventura images. The option might need to be disabled on
+          older VM images." >
+          <f:checkbox default="true" />
+        </f:entry>
+
         <f:entry title="${%Memory in G}" field="memory" help="${descriptor.getHelpFile('memory')}">
           <f:textbox checkMethod="post" default="auto"/>
         </f:entry>

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -19,9 +19,8 @@
           <c:select />
         </f:entry>
 
-        <f:entry title="${%Use Net Boost}" field="useNetBoost" description="If checked, use Net Boost. This leads to
-          better network throughput and is required for booting Ventura images. The option might need to be disabled on
-          older VM images." >
+        <f:entry title="${%Use Net Boost}" field="useNetBoost" description="If checked, use Net Boost. This option is
+          required for booting macOS Ventura images. It must be disabled for Mojave and Catalina, as they don't support it.">
           <f:checkbox default="true" />
         </f:entry>
 

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -52,6 +52,12 @@
         <c:select />
       </f:entry>
 
+      <f:entry title="${%Use Net Boost}" field="useNetBoost" description="If checked, use Net Boost. This leads to
+        better network throughput and is required for booting Ventura images. The option might need to be disabled on
+        older VM images." >
+        <f:checkbox default="true" />
+      </f:entry>
+
       <f:entry title="${%Memory in G}" field="memory" help="${descriptor.getHelpFile('memory')}">
         <f:textbox checkMethod="post" default="auto"/>
       </f:entry>

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -52,9 +52,8 @@
         <c:select />
       </f:entry>
 
-      <f:entry title="${%Use Net Boost}" field="useNetBoost" description="If checked, use Net Boost. This leads to
-        better network throughput and is required for booting Ventura images. The option might need to be disabled on
-        older VM images." >
+      <f:entry title="${%Use Net Boost}" field="useNetBoost" description="If checked, use Net Boost. This option is
+        required for booting macOS Ventura images. It must be disabled for Mojave and Catalina, as they don't support it.">
         <f:checkbox default="true" />
       </f:entry>
 

--- a/src/test/java/io/jenkins/plugins/orka/client/OrkaClientTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/client/OrkaClientTest.java
@@ -1,6 +1,7 @@
 package io.jenkins.plugins.orka.client;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.endsWith;
@@ -97,12 +98,13 @@ public class OrkaClientTest {
 
         OrkaClient client = mock(OrkaClient.class);
         when(client.post(anyString(), anyString())).thenReturn(response);
-        when(client.createConfiguration(anyString(), anyString(), anyString(), anyString(), anyInt(), anyString(),
-                anyString()))
+        when(client.createConfiguration(anyString(), anyString(), anyString(), anyString(), anyInt(), anyBoolean(),
+                anyString(), anyString()))
                 .thenCallRealMethod();
 
-        ConfigurationResponse actualResponse = client.createConfiguration("newVm", "image", "baseImage", "default", 24,
-                "most-allocated", "10");
+        ConfigurationResponse actualResponse = client.createConfiguration(
+            "newVm", "image", "baseImage", "default", 24,
+            false, "most-allocated", "10");
 
         assertEquals(message, actualResponse.getMessage());
     }


### PR DESCRIPTION
Net Boost is required for newer Ventura VMs, but may have to be forcibly disabled for older OS images. Expose a checkbox for controlling this behaviour.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
