### PR TITLE
Fix overzealous auth token revocation

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -59,9 +59,17 @@ public class OrkaClient implements AutoCloseable {
     public OrkaClient(String endpoint, String email, String password, int httpClientTimeout, Proxy proxy,
             boolean ignoreSSLErrors)
             throws IOException {
+        this(endpoint, email, password, httpClientTimeout, proxy, ignoreSSLErrors, true);
+    }
+
+    public OrkaClient(String endpoint, String email, String password, int httpClientTimeout, Proxy proxy,
+            boolean ignoreSSLErrors, boolean initToken)
+            throws IOException {
         this.client = this.createClient(proxy, httpClientTimeout, ignoreSSLErrors);
         this.endpoint = endpoint;
-        this.initToken(email, password);
+        if (initToken) {
+            this.initToken(email, password);
+        }
     }
 
     public OrkaClient(String endpoint, int httpClientTimeout, Proxy proxy,

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
@@ -121,18 +121,22 @@ public class OrkaClientProxy {
     }
 
     public HealthCheckResponse getHealthCheck() throws IOException {
-        try (OrkaClient client = getOrkaClient()) {
+        try (OrkaClient client = getOrkaClient(false)) {
             return client.getHealthCheck();
         }
     }
 
     private OrkaClient getOrkaClient() throws IOException {
+        return getOrkaClient(true);
+    }
+
+    private OrkaClient getOrkaClient(boolean initToken) throws IOException {
         if (StringUtils.isBlank(this.serverVersion)
                 || Utils.compareVersions(this.serverVersion, firstVersionWithSingleToken) < 0) {
 
             return new OrkaClient(this.endpoint, this.credentials.getUsername(),
                     Secret.toString(credentials.getPassword()),
-                    this.httpClientTimeout, this.proxy, this.ignoreSSLErrors);
+                    this.httpClientTimeout, this.proxy, this.ignoreSSLErrors, initToken);
         }
 
         return new OrkaClientV2(this.endpoint, this.credentials.getUsername(),


### PR DESCRIPTION
Whenever we perform a health check, we are recreating an `OrkaClient`. If we're on Orka versions lower than 2.1.1, or it's the first time we are performing the check after Jenkins restart, this forces the reinitialization of the authentication token. This means that any active tokens are revoked and therefore the users are logged out from all of their other systems (such as CLI, web UI).

Because the health check doesn't actually need an authentication token, just skip generating one for this case (and thereby skip revoking it when the client is closed shortly).

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
