### PR TITLE
Fix incorrectly revoking tokens on fresh plugin install

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/CloudSaveListener.java
+++ b/src/main/java/io/jenkins/plugins/orka/CloudSaveListener.java
@@ -1,0 +1,18 @@
+package io.jenkins.plugins.orka;
+
+import hudson.Extension;
+import hudson.XmlFile;
+import hudson.model.Saveable;
+import hudson.model.listeners.SaveableListener;
+
+import jenkins.model.Jenkins;
+
+@Extension
+public final class CloudSaveListener extends SaveableListener {
+    @Override
+    public void onChange(Saveable o, XmlFile file) {
+        if (o instanceof Jenkins) {
+            OrkaVersionChecker.updateOrkaVersion();
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientProxy.java
@@ -99,12 +99,12 @@ public class OrkaClientProxy {
     }
 
     public ConfigurationResponse createConfiguration(
-        String vmName, String image, String baseImage, String configTemplate, int cpuCount, boolean useNetBoost,
-        String scheduler, String memory, String tag, Boolean tagRequired) throws IOException {
+            String vmName, String image, String baseImage, String configTemplate, int cpuCount, boolean useNetBoost,
+            String scheduler, String memory, String tag, Boolean tagRequired) throws IOException {
         try (OrkaClient client = getOrkaClient()) {
             return client.createConfiguration(
-                vmName, image, baseImage, configTemplate, cpuCount, useNetBoost, scheduler, memory, tag, tagRequired
-            );
+                    vmName, image, baseImage, configTemplate, cpuCount, useNetBoost, scheduler, memory, tag,
+                    tagRequired);
         }
     }
 
@@ -117,12 +117,12 @@ public class OrkaClientProxy {
     }
 
     public DeploymentResponse deployVM(String vmName, String node,
-        String scheduler) throws IOException {
+            String scheduler) throws IOException {
         return this.deployVM(vmName, node, scheduler, null, null);
     }
 
     public DeploymentResponse deployVM(String vmName, String node, String scheduler,
-        String tag, Boolean tagRequired) throws IOException {
+            String tag, Boolean tagRequired) throws IOException {
         try (OrkaClient client = getOrkaClient()) {
             return client.deployVM(vmName, node, scheduler, tag, tagRequired);
         }
@@ -151,8 +151,8 @@ public class OrkaClientProxy {
     }
 
     private OrkaClient getOrkaClient(boolean initToken) throws IOException {
-        if (StringUtils.isBlank(this.serverVersion)
-                || Utils.compareVersions(this.serverVersion, firstVersionWithSingleToken) < 0) {
+        if (!StringUtils.isBlank(this.serverVersion)
+                && Utils.compareVersions(this.serverVersion, firstVersionWithSingleToken) < 0) {
 
             return new OrkaClient(this.endpoint, this.credentials.getUsername(),
                     Secret.toString(credentials.getPassword()),


### PR DESCRIPTION
During a fresh plugin install there is no cloud, so our logic does not set a server version. This results in a token being revoke on each request once a cloud has been added.

To fix that:
1. Change the default behavior not to revoke tokens if there is no version
2. Listen for Jenkins config changes and update the version. This would handle the addition of a new cluster.
