### PR TITLE
Handle token revocation with permanent agents

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -77,6 +77,9 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
             return;
         }
 
+        OrkaVersionChecker.updateOrkaVersion(agent.getOrkaEndpoint(), agent.getOrkaCredentialsId(),
+                agent.getUseJenkinsProxySettings(), agent.getIgnoreSSLErrors());
+
         OrkaClientProxy client = new OrkaClientProxyFactory().getOrkaClientProxy(agent.getOrkaEndpoint(),
                 agent.getOrkaCredentialsId(), agent.getUseJenkinsProxySettings(), agent.getIgnoreSSLErrors());
 
@@ -151,7 +154,7 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
         String vmName = agent.getCreateNewVMConfig() ? agent.getConfigName() : agent.getVm();
 
         DeploymentResponse deploymentResponse = clientProxy.deployVM(vmName, agent.getNode(),
-            null, agent.getTag(), agent.getTagRequired());
+                null, agent.getTag(), agent.getTagRequired());
 
         if (!deploymentResponse.isSuccessful()) {
             logger.println(

--- a/src/main/java/io/jenkins/plugins/orka/OrkaVersionChecker.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaVersionChecker.java
@@ -42,4 +42,21 @@ public class OrkaVersionChecker {
             }
         }
     }
+
+    public static void updateOrkaVersion(String endpoint, String credentialsId,
+            boolean useJenkinsProxySettings, boolean ignoreSSLErrors) {
+        logger.fine("Checking Orka version for endpoint: " + endpoint);
+
+        try {
+            HealthCheckResponse healthCheck = clientFactory
+                    .getOrkaClientProxy(endpoint, credentialsId,
+                            useJenkinsProxySettings, ignoreSSLErrors)
+                    .getHealthCheck();
+
+            logger.fine("Server: " + endpoint + ". Version: " + healthCheck.getApiVersion());
+            OrkaClientProxyFactory.setServerVersion(endpoint, healthCheck.getApiVersion());
+        } catch (Exception e) {
+            logger.warning("Error while getting Orka version: " + e.getMessage());
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/orka/OrkaVersionChecker.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaVersionChecker.java
@@ -28,22 +28,20 @@ public class OrkaVersionChecker {
         for (Cloud cloud : jenkinsInstance.clouds) {
             if ((cloud instanceof OrkaCloud)) {
                 OrkaCloud orka = (OrkaCloud) cloud;
-                try {
-                    HealthCheckResponse healthCheck = clientFactory
-                            .getOrkaClientProxy(orka.getEndpoint(), orka.getCredentialsId(), orka.getHttpTimeout(),
-                                    orka.getUseJenkinsProxySettings(), orka.getIgnoreSSLErrors())
-                            .getHealthCheck();
-
-                    logger.fine("Server: " + orka.getEndpoint() + ". Version: " + healthCheck.getApiVersion());
-                    OrkaClientProxyFactory.setServerVersion(orka.getEndpoint(), healthCheck.getApiVersion());
-                } catch (Exception e) {
-                    logger.warning("Error while getting Orka version: " + e.getMessage());
-                }
+                updateOrkaVersion(orka.getEndpoint(), orka.getCredentialsId(), orka.getHttpTimeout(),
+                        orka.getUseJenkinsProxySettings(), orka.getIgnoreSSLErrors());
             }
         }
     }
 
     public static void updateOrkaVersion(String endpoint, String credentialsId,
+            boolean useJenkinsProxySettings, boolean ignoreSSLErrors) {
+        logger.fine("Checking Orka version for endpoint: " + endpoint);
+
+        updateOrkaVersion(endpoint, credentialsId, 0, useJenkinsProxySettings, ignoreSSLErrors);
+    }
+
+    private static void updateOrkaVersion(String endpoint, String credentialsId, int httpTimeout,
             boolean useJenkinsProxySettings, boolean ignoreSSLErrors) {
         logger.fine("Checking Orka version for endpoint: " + endpoint);
 


### PR DESCRIPTION
Currently, the logic for token revocation was only working for ephemeral agents. Update it to work for permanent as well

