### PR TITLE
OK-2917 Allow using SecretText for storing tokens

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -67,6 +69,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <version>2.3.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>plain-credentials</artifactId>
+            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>

--- a/src/main/java/io/jenkins/plugins/orka/helpers/CredentialsHelper.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/CredentialsHelper.java
@@ -3,14 +3,16 @@ package io.jenkins.plugins.orka.helpers;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.PasswordCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
-
+import hudson.util.Secret;
 import java.util.Collections;
 import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 public final class CredentialsHelper {
     public static StandardUsernamePasswordCredentials lookupSystemCredentials(final String credentialsId) {
@@ -23,8 +25,26 @@ public final class CredentialsHelper {
                 CredentialsMatchers.withId(credentialsId));
     }
 
+    public static StringCredentials lookupStringCredentials(final String credentialsId) {
+        return lookupSystemCredentials(credentialsId, StringCredentials.class);
+    }
+
+    public static Secret lookupTokenSecret(final String credentialsId) {
+        StringCredentials stringCredential = CredentialsHelper.lookupStringCredentials(credentialsId);
+        if (stringCredential != null) {
+            return stringCredential.getSecret();
+        }
+
+        PasswordCredentials passwordCredentials = CredentialsHelper.lookupSystemCredentials(credentialsId);
+        if (passwordCredentials != null) {
+            return passwordCredentials.getPassword();
+        }
+        return null;
+    }
+
     public static ListBoxModel getCredentials(Class type) {
         return new StandardListBoxModel().includeEmptyValue().includeMatchingAs(ACL.SYSTEM, Jenkins.get(), type,
                 Collections.emptyList(), CredentialsMatchers.always());
     }
+
 }

--- a/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientFactory.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/OrkaClientFactory.java
@@ -25,8 +25,8 @@ public class OrkaClientFactory {
     public OrkaClient getOrkaClient(String endpoint, String credentialsId, int httpClientTimeout,
             boolean useJenkinsProxySettings, boolean ignoreSSLErrors) throws IOException {
 
-        PasswordCredentials credentials = CredentialsHelper.lookupSystemCredentials(credentialsId);
-        return new OrkaClient(endpoint, Secret.toString(credentials.getPassword()), httpClientTimeout,
+        Secret secret = CredentialsHelper.lookupTokenSecret(credentialsId);
+        return new OrkaClient(endpoint, Secret.toString(secret), httpClientTimeout,
                 this.getProxy(endpoint, useJenkinsProxySettings), ignoreSSLErrors);
     }
 

--- a/src/test/java/io/jenkins/plugins/orka/OrkaAgentDescriptorImplTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/OrkaAgentDescriptorImplTest.java
@@ -8,13 +8,15 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import hudson.util.Secret;
 
 public class OrkaAgentDescriptorImplTest {
     @ClassRule
@@ -48,6 +50,27 @@ public class OrkaAgentDescriptorImplTest {
         assertEquals(2, model.size());
         assertEquals("", model.get(0).value);
         assertEquals(credentials.getId(), model.get(1).value);
+    }
+
+    @Test
+    public void when_do_fill_orka_credentials_id_items_with_different_credential_should_return_three_credentials()
+            throws IOException {
+        OrkaAgent.DescriptorImpl descriptor = new OrkaAgent.DescriptorImpl();
+        UsernamePasswordCredentialsImpl credentials = new UsernamePasswordCredentialsImpl(CredentialsScope.SYSTEM,
+                "uniqueId", "description", "foo", "bar");
+
+        StringCredentials stringCredentials = new StringCredentialsImpl(
+                CredentialsScope.SYSTEM, "stringId", "description", Secret.fromString("someSecret"));
+        SystemCredentialsProvider.getInstance().getCredentials().clear();
+        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        SystemCredentialsProvider.getInstance().getCredentials().add(stringCredentials);
+        SystemCredentialsProvider.getInstance().save();
+
+        ListBoxModel model = descriptor.doFillOrkaCredentialsIdItems();
+        assertEquals(3, model.size());
+        assertEquals("", model.get(0).value);
+        assertEquals(credentials.getId(), model.get(2).value);
+        assertEquals(stringCredentials.getId(), model.get(1).value);
     }
 
     @Test


### PR DESCRIPTION
## Description

Currently, we only allow Username/Password credentials. However, this is counter-intuitive as we want users to only store tokens. Allow SecretText as well, which is intended for tokens

## Testing

1. Install the plugin
2. Create a new Orka Cloud
3. Add the Orka token as a SecretText
4. Run "Verify Connection"

Should be successful