### PR TITLE
OK-2934 Fix server timeout when deploying VMs

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
@@ -35,6 +35,10 @@ public class DeploymentRequest {
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     private float memory;
 
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    private int timeout;
+
+    @Deprecated
     public DeploymentRequest(String vmConfig, String name, String node, String scheduler,
             String tag, Boolean tagRequired) {
         this.vmConfig = vmConfig;
@@ -60,5 +64,6 @@ public class DeploymentRequest {
         this.tagRequired = tagRequired != null ? tagRequired : null;
         this.name = name;
         this.shouldGenerateName = StringUtils.isNotBlank(this.name);
+        this.timeout = 60 * 24; // Set the server timeout to a day
     }
 }


### PR DESCRIPTION
Orka server has a default timeout of 10 minutes. We can increase this timeout. However, there isn't need for that in the plugin. We already have a request timeout for deployment, so we keep using it. Make sure to increase the server timeout to a day, so it is always greater than the request timeout. Essentially we make sure than the server timeout never kicks in