### PR TITLE
Ok 3299  Allow Port Mapping for permanent agents

### DIFF
--- a/development/DEVELOPING.md
+++ b/development/DEVELOPING.md
@@ -12,6 +12,7 @@ This guide provides information about how to build, package, and run the plugin 
   - [UI Bindings](#ui-bindings)
 - [Persisting State](#persisting-state)
 - [Changing the Supported Jenkins Version](#changing-the-supported-jenkins-version)
+- [Changing Plugin Version](#changing-the-plugin-version)
 
 ## Build Requirements
 
@@ -99,3 +100,6 @@ We only support [Jenkins LTS versions][lts]. The minimum supported version is sp
 ```
 
 [lts]: https://www.jenkins.io/changelog-stable/
+
+## Changing Plugin Version
+The plugin version is set in the Github runner when the plugin is released (see [Releasing Guide](RELEASING.md) for details)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>macstadium-orka</artifactId>
-    <version>2.05-SNAPSHOT</version>
+    <version>2.05</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.204.1</jenkins.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>macstadium-orka</artifactId>
-    <version>2.05</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.204.1</jenkins.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>macstadium-orka</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.05-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
         <jenkins.version>2.204.1</jenkins.version>

--- a/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
@@ -186,26 +186,6 @@ public class OrkaAgent extends AbstractCloudSlave {
         return portMappings;
     }
 
-    /* 
-    public void processPortMappings() {
-        for (PortMapping mapping : portMappings) {
-            int fromPort = mapping.getFrom();
-            int toPort = mapping.getTo();
-
-            if (isValidPortRange(fromPort)) {
-                logger.fine("Mapping from port " + fromPort + " to port " + toPort);
-            } else {
-                logger.fine("Invalid port mapping: from " + fromPort + " to " + toPort);
-            }
-        }
-    }
-
-    */
-    
-    private boolean isValidPortRange(int from) {
-        return from >= 1024 && from <= 65535;
-    }
-
     public String getPortMappingsAsString() {
         if (portMappings == null || portMappings.isEmpty()) {
             return "";

--- a/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import jenkins.model.Jenkins;
 
@@ -84,6 +83,35 @@ public class OrkaAgent extends AbstractCloudSlave {
         this.tagRequired = tagRequired;
         this.setNumExecutors(numExecutors);
         this.portMappings = portMappings != null ? portMappings : new ArrayList<>();        
+    }
+
+    public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId,
+            String node, String namespace, String namePrefix, String redirectHost, String image,
+            Integer cpu, boolean useNetBoost, boolean useLegacyIO, boolean useGpuPassthrough, 
+            int numExecutors, String host, int port, String remoteFS, boolean useJenkinsProxySettings, 
+            boolean ignoreSSLErrors, String jvmOptions, String memory, String tag, Boolean tagRequired)
+            throws Descriptor.FormException, IOException {
+        super(name, remoteFS, new OrkaComputerLauncher(host, port, redirectHost, jvmOptions));
+
+        this.orkaCredentialsId = orkaCredentialsId;
+        this.orkaEndpoint = orkaEndpoint;
+        this.vmCredentialsId = vmCredentialsId;
+        this.namespace = namespace;
+        this.namePrefix = namePrefix;
+        this.node = node;
+        this.image = image;
+        this.cpu = cpu;
+        this.useNetBoost = useNetBoost;
+        this.useLegacyIO = useLegacyIO;
+        this.useGpuPassthrough = useGpuPassthrough;
+        this.useJenkinsProxySettings = useJenkinsProxySettings;
+        this.ignoreSSLErrors = ignoreSSLErrors;
+        this.jvmOptions = jvmOptions;
+        this.memory = memory;
+        this.tag = tag;
+        this.tagRequired = tagRequired;
+        this.setNumExecutors(numExecutors);
+        this.portMappings = null;
     }
 
     public String getOrkaCredentialsId() {
@@ -158,19 +186,22 @@ public class OrkaAgent extends AbstractCloudSlave {
         return portMappings;
     }
 
+    /* 
     public void processPortMappings() {
         for (PortMapping mapping : portMappings) {
             int fromPort = mapping.getFrom();
             int toPort = mapping.getTo();
 
             if (isValidPortRange(fromPort)) {
-                logger.info("Mapping from port " + fromPort + " to port " + toPort);
+                logger.fine("Mapping from port " + fromPort + " to port " + toPort);
             } else {
-                logger.info("Invalid port mapping: from " + fromPort + " to " + toPort);
+                logger.fine("Invalid port mapping: from " + fromPort + " to " + toPort);
             }
         }
     }
 
+    */
+    
     private boolean isValidPortRange(int from) {
         return from >= 1024 && from <= 65535;
     }

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -186,7 +186,7 @@ public class OrkaCloud extends Cloud {
                 .getOrkaClient(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
                         this.ignoreSSLErrors)
                 .deployVM(vmConfig, namespace, namePrefix, image, cpu, memory, null, 
-                          scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough);
+                          scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, null);
     }
 
     public void deleteVM(String name, String namespace) throws IOException {

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -116,7 +116,7 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
                 agent.getNode(),
                 null, agent.getTag(), agent.getTagRequired(),
                 agent.getUseNetBoost(), agent.getUseLegacyIO(), agent.getUseGpuPassthrough(), 
-                agent.getPortMappingAsString());
+                agent.getPortMappingsAsString());
 
         if (!deploymentResponse.isSuccessful()) {
             logger.println(

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -115,7 +115,8 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
                 agent.getNamespace(), agent.getNamePrefix(), agent.getImage(), agent.getCpu(), agent.getMemory(),
                 agent.getNode(),
                 null, agent.getTag(), agent.getTagRequired(),
-                agent.getUseNetBoost(), agent.getUseLegacyIO(), agent.getUseGpuPassthrough());
+                agent.getUseNetBoost(), agent.getUseLegacyIO(), agent.getUseGpuPassthrough(), 
+                agent.getPortMappingAsString());
 
         if (!deploymentResponse.isSuccessful()) {
             logger.println(

--- a/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
@@ -47,6 +47,9 @@ public class DeploymentRequest {
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     private int timeout;
 
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    private String reservedPorts;
+
     @Deprecated
     public DeploymentRequest(String vmConfig, String name, String node, String scheduler,
             String tag, Boolean tagRequired) {
@@ -61,7 +64,7 @@ public class DeploymentRequest {
 
     public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
             String scheduler, String tag, Boolean tagRequired, Boolean netBoost, 
-            Boolean legacyIO, Boolean gpuPassthrough) {
+            Boolean legacyIO, Boolean gpuPassthrough, String portMappingString) {
         this.vmConfig = vmConfig;
         this.node = node;
         this.image = image;
@@ -82,5 +85,7 @@ public class DeploymentRequest {
         }
         this.shouldGenerateName = StringUtils.isNotBlank(this.name);
         this.timeout = 60 * 24; // Set the server timeout to a day
+
+        this.reservedPorts = portMappingString;
     }
 }

--- a/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
@@ -63,6 +63,32 @@ public class DeploymentRequest {
     }
 
     public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
+        String scheduler, String tag, Boolean tagRequired, Boolean netBoost, 
+        Boolean legacyIO, Boolean gpuPassthrough) {
+        this.vmConfig = vmConfig;
+        this.node = node;
+        this.image = image;
+        this.cpu = cpu;
+        if (!StringUtils.isBlank(memory) && !StringUtils.equals(memory, "auto") && Float.parseFloat(memory) > 0) {
+            this.memory = Float.parseFloat(memory);
+        }
+        this.scheduler = StringUtils.isNotBlank(scheduler) ? scheduler : null;
+        this.tag = StringUtils.isNotBlank(tag) && tag != null ? tag : null;
+        this.tagRequired = tagRequired != null ? tagRequired : null;
+        this.name = name;
+        this.netBoost = netBoost;
+        this.legacyIO = legacyIO;
+        this.gpuPassthrough = gpuPassthrough;
+
+        if (this.legacyIO) {
+            this.netBoost = false;
+        }
+
+        this.shouldGenerateName = StringUtils.isNotBlank(this.name);
+        this.timeout = 60 * 24; // Set the server timeout to a day
+    }
+
+    public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
             String scheduler, String tag, Boolean tagRequired, Boolean netBoost, 
             Boolean legacyIO, Boolean gpuPassthrough, String portMappingsString) {
         this.vmConfig = vmConfig;

--- a/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
@@ -64,7 +64,7 @@ public class DeploymentRequest {
 
     public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
             String scheduler, String tag, Boolean tagRequired, Boolean netBoost, 
-            Boolean legacyIO, Boolean gpuPassthrough, String portMappingString) {
+            Boolean legacyIO, Boolean gpuPassthrough, String portMappingsString) {
         this.vmConfig = vmConfig;
         this.node = node;
         this.image = image;
@@ -86,6 +86,6 @@ public class DeploymentRequest {
         this.shouldGenerateName = StringUtils.isNotBlank(this.name);
         this.timeout = 60 * 24; // Set the server timeout to a day
 
-        this.reservedPorts = portMappingString;
+        this.reservedPorts = portMappingsString;
     }
 }

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -91,9 +91,10 @@ public class OrkaClient {
             String memory, String node,
             String scheduler,
             String tag, Boolean tagRequired,Boolean netBoost, Boolean legacyIO, 
-            Boolean gpuPassThrough, String portMappingString) throws IOException {
+            Boolean gpuPassThrough, String portMappingsString) throws IOException {
+
         DeploymentRequest deploymentRequest = new DeploymentRequest(vmConfig, namePrefix, image, cpu, memory, node,
-                scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, portMappingString);
+                scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, portMappingsString);
         String deploymentRequestJson = new Gson().toJson(deploymentRequest);
 
         HttpResponse httpResponse = this.post(

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -6,6 +6,7 @@ import com.google.gson.Gson;
 import java.io.IOException;
 import java.net.Proxy;
 import java.util.Arrays;
+
 import java.util.concurrent.TimeUnit;
 
 import java.util.logging.Logger;
@@ -90,10 +91,9 @@ public class OrkaClient {
             String memory, String node,
             String scheduler,
             String tag, Boolean tagRequired,Boolean netBoost, Boolean legacyIO, 
-            Boolean gpuPassThrough) throws IOException {
+            Boolean gpuPassThrough, String portMappingString) throws IOException {
         DeploymentRequest deploymentRequest = new DeploymentRequest(vmConfig, namePrefix, image, cpu, memory, node,
-                scheduler, tag,
-                tagRequired, netBoost, legacyIO, gpuPassThrough);
+                scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, portMappingString);
         String deploymentRequestJson = new Gson().toJson(deploymentRequest);
 
         HttpResponse httpResponse = this.post(

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -89,7 +89,7 @@
             </f:entry>
             
             <f:entry title="VM Port" field="to">
-                <f:number/>
+                <f:number min="1024" max="65535"/>
             </f:entry>
           
             <f:entry title="">

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/io/jenkins/temp/jelly">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:s="/io/jenkins/temp/jelly" xmlns:orka="/lib/orka">
 
   <f:section title="${%ORKA Config}">
 
@@ -81,16 +81,27 @@
       <f:textbox/>
     </f:entry>
 
-    <f:entry title="Port Mapping" field="portMapping" description="Please enter the 'from' and 'to' ports for port mapping. Only ports between 1024 and 65535 are allowed.">
-      <f:repeatable var="entry" name="portMapping">
-          <f:entry title="From Port" field="from">
-              <f:number min="1024" max="65535" />
-          </f:entry>
-          <f:entry title="To Port" field="to">
-              <f:number min="1024" max="65535" />
-          </f:entry>
-      </f:repeatable>
-    </f:entry>
+    <orka:blockWrapper>
+      <f:entry title="Port Mapping" field="portMappings" description="Please enter the NODE and VM ports for port mapping. Only NODE ports between 1024 and 65535 are allowed.">
+        <f:repeatable var="entry" name="portMappings">
+            <f:entry title="Node Port" field="from">
+                <f:number />
+            </f:entry>
+            
+            <f:entry title="VM Port" field="to">
+                <f:number min="1024" max="65535"/>
+            </f:entry>
+          
+            <f:entry title="">
+              <div align="right">
+                <f:repeatableDeleteButton value="${%Delete Mapping}"/>
+              </div>
+            </f:entry>
+        </f:repeatable>
+      </f:entry>
+
+      
+    </orka:blockWrapper>
 
   </f:section>
 

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -82,14 +82,14 @@
     </f:entry>
 
     <orka:blockWrapper>
-      <f:entry title="Port Mapping" field="portMappings" description="Please enter the NODE and VM ports for port mapping. Only NODE ports between 1024 and 65535 are allowed.">
+      <f:entry title="Port Mapping" field="portMappings" description="Please enter the Node and VM ports for port mapping. Only Node ports between 1024 and 65535 are allowed.">
         <f:repeatable var="entry" name="portMappings">
             <f:entry title="Node Port" field="from">
-                <f:number />
+                <f:number min="1024" max="65535"/>
             </f:entry>
             
             <f:entry title="VM Port" field="to">
-                <f:number min="1024" max="65535"/>
+                <f:number/>
             </f:entry>
           
             <f:entry title="">

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -89,7 +89,7 @@
             </f:entry>
             
             <f:entry title="VM Port" field="to">
-                <f:number min="1024" max="65535"/>
+                <f:number/>
             </f:entry>
           
             <f:entry title="">

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -80,6 +80,18 @@
     <f:entry title="${%Name Prefix}" field="namePrefix" help="${descriptor.getHelpFile('namePrefix')}">
       <f:textbox/>
     </f:entry>
+
+    <f:entry title="Port Mapping" field="portMapping" description="Please enter the 'from' and 'to' ports for port mapping. Only ports between 1024 and 65535 are allowed.">
+      <f:repeatable var="entry" name="portMapping">
+          <f:entry title="From Port" field="from">
+              <f:number min="1024" max="65535" />
+          </f:entry>
+          <f:entry title="To Port" field="to">
+              <f:number min="1024" max="65535" />
+          </f:entry>
+      </f:repeatable>
+    </f:entry>
+
   </f:section>
 
   <f:section title="${%Agent Details}">

--- a/src/test/java/io/jenkins/plugins/orka/client/OrkaClientTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/client/OrkaClientTest.java
@@ -78,12 +78,12 @@ public class OrkaClientTest {
         OrkaClient client = mock(OrkaClient.class);
         when(client.post(anyString(), any())).thenReturn(response);
         when(client.deployVM(any(), anyString(), any(), any(), any(), any(), any(), any(),
-                any(), any(), any(), any(), any()))
+                any(), any(), any(), any(), any(), any()))
                 .thenCallRealMethod();
 
         DeploymentResponse actualResponse = client.deployVM("newVm", "orka-default", null, "foo.img", 6, "12", null,
                 null,
-                null, false,false, false, false);
+                null, false,false, false, false, null);
 
         assertEquals(ip, actualResponse.getIP());
         assertEquals(sshPort, actualResponse.getSSH());


### PR DESCRIPTION
### Change Description
Updated Jelly files to add widget for users to create custom port mapping when creating VMs. Updated backend Java code to process the port mapping inputs and pass the ports the method that creates the VM.

### Testing done

This change was tested inside of Jenkins. A permanent agent was created with three custom port mappings.  The VM was created correctly with the custom ports.

<img width="1238" alt="Screenshot 2024-11-21 at 10 32 20 AM" src="https://github.com/user-attachments/assets/ea60f7a7-bf58-47ad-8f9c-7b2d75e3bc57">


<img width="1143" alt="Screenshot 2024-11-14 at 10 23 00 PM" src="https://github.com/user-attachments/assets/3055769d-d4ec-448c-b916-6b9f84cd22cc">



### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
