### PR TITLE
OK-3786 Ensure no orphaned VMs

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -177,6 +177,7 @@ public class OrkaCloud extends Cloud {
                 .getVMConfigs().getConfigs();
     }
 
+    @Deprecated
     public DeploymentResponse deployVM(String namespace, String namePrefix, String vmConfig, String image, Integer cpu,
             String memory, String scheduler,
             String tag,
@@ -187,6 +188,17 @@ public class OrkaCloud extends Cloud {
                         this.ignoreSSLErrors)
                 .deployVM(vmConfig, namespace, namePrefix, image, cpu, memory, null, 
                           scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, null);
+    }
+
+    public DeploymentResponse deployVMWithName(String namespace, String name, String vmConfig, String image, 
+            Integer cpu, String memory, String scheduler, String tag,
+            Boolean tagRequired, Boolean netBoost, Boolean legacyIO, 
+            Boolean gpuPassThrough) throws IOException {
+        return new OrkaClientFactory()
+                .getOrkaClient(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
+                        this.ignoreSSLErrors)
+                .deployVMWithName(vmConfig, namespace, name, image, cpu, memory, null, 
+                        scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, null);
     }
 
     public void deleteVM(String name, String namespace) throws IOException {

--- a/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
@@ -62,6 +62,7 @@ public class DeploymentRequest {
         this.shouldGenerateName = StringUtils.isNotBlank(this.name);
     }
 
+    @Deprecated
     public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
         String scheduler, String tag, Boolean tagRequired, Boolean netBoost, 
         Boolean legacyIO, Boolean gpuPassthrough) {
@@ -88,9 +89,17 @@ public class DeploymentRequest {
         this.timeout = 60 * 24; // Set the server timeout to a day
     }
 
+    @Deprecated
     public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
             String scheduler, String tag, Boolean tagRequired, Boolean netBoost, 
             Boolean legacyIO, Boolean gpuPassthrough, String portMappingsString) {
+        this(vmConfig, name, image, cpu, memory, node, scheduler, tag, tagRequired, netBoost, 
+            legacyIO, gpuPassthrough, portMappingsString, StringUtils.isNotBlank(name));
+    }
+
+    public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
+        String scheduler, String tag, Boolean tagRequired, Boolean netBoost, Boolean legacyIO, Boolean gpuPassthrough, 
+        String portMappingsString, Boolean shouldGenerateName) {
         this.vmConfig = vmConfig;
         this.node = node;
         this.image = image;
@@ -109,7 +118,7 @@ public class DeploymentRequest {
         if (this.legacyIO) {
             this.netBoost = false;
         }
-        this.shouldGenerateName = StringUtils.isNotBlank(this.name);
+        this.shouldGenerateName = shouldGenerateName;
         this.timeout = 60 * 24; // Set the server timeout to a day
 
         this.reservedPorts = portMappingsString;

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -87,6 +87,7 @@ public class OrkaClient {
         return response;
     }
 
+    @Deprecated
     public DeploymentResponse deployVM(String vmConfig, String namespace, String namePrefix, String image, Integer cpu,
             String memory, String node,
             String scheduler,
@@ -95,6 +96,23 @@ public class OrkaClient {
 
         DeploymentRequest deploymentRequest = new DeploymentRequest(vmConfig, namePrefix, image, cpu, memory, node,
                 scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, portMappingsString);
+        String deploymentRequestJson = new Gson().toJson(deploymentRequest);
+
+        HttpResponse httpResponse = this.post(
+                String.format("%s/%s/%s/%s", this.endpoint, RESOURCE_PATH, namespace, VM_PATH), deploymentRequestJson);
+        DeploymentResponse response = JsonHelper.fromJson(httpResponse.getBody(), DeploymentResponse.class);
+        response.setHttpResponse(httpResponse);
+
+        return response;
+    }
+
+    public DeploymentResponse deployVMWithName(String vmConfig, String namespace, String name, 
+            String image, Integer cpu, String memory, String node, String scheduler, String tag, 
+            Boolean tagRequired, Boolean netBoost, Boolean legacyIO, Boolean gpuPassThrough, 
+            String portMappingsString) throws IOException {
+
+        DeploymentRequest deploymentRequest = new DeploymentRequest(vmConfig, name, image, cpu, memory, node,
+                scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, portMappingsString, false);
         String deploymentRequestJson = new Gson().toJson(deploymentRequest);
 
         HttpResponse httpResponse = this.post(

--- a/src/main/java/io/jenkins/plugins/orka/helpers/VMNameGenerator.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/VMNameGenerator.java
@@ -1,0 +1,27 @@
+package io.jenkins.plugins.orka.helpers;
+
+import java.security.SecureRandom;
+import org.apache.commons.lang.StringUtils;
+
+public class VMNameGenerator {
+    
+    private static final String charset = "abcdefghijklmnopqrstuvwxyz0123456789";
+    private static final int randomSuffixLength = 5;
+    private static final SecureRandom random = new SecureRandom();
+    private static final String defaultPrefix = "vm";
+    
+    public static String generateName(String prefix) {
+        if (StringUtils.isBlank(prefix)) {
+            prefix = defaultPrefix;
+        }
+
+        StringBuilder result = new StringBuilder(prefix.length() + 1 + randomSuffixLength);
+        result.append(prefix).append("-");
+        
+        for (int i = 0; i < randomSuffixLength; i++) {
+            result.append(charset.charAt(random.nextInt(charset.length())));
+        }
+        
+        return result.toString();
+    }
+}

--- a/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
@@ -30,7 +30,7 @@ public class AgentTemplateTest {
         String id = "vm-machine";
 
         OrkaCloud cloud = mock(OrkaCloud.class);
-        when(cloud.deployVM(any(), any(), any(), any(), any(), any(), any(), any(),
+        when(cloud.deployVMWithName(any(), any(), any(), any(), any(), any(), any(), any(),
                 any(), any(), any(), any()))
                 .thenReturn(new DeploymentResponse(ip, sshPort, id, null));
         when(cloud.getRealHost(anyString())).thenReturn(ip);
@@ -48,12 +48,7 @@ public class AgentTemplateTest {
         assertEquals(id, provisionedAgent.getVmId());
     }
 
-    private AgentTemplate getAgentTemplate() {
-        return new AgentTemplate("vmCredentialsId", "my-vm", false, "configName", "baseImage", 12, true,
-                false, false, 1,
-                "remoteFS",
-                Mode.NORMAL, "label", "prefix", new IdleTimeCloudRetentionStrategy(5),
-                null,
-                Collections.emptyList(), null, "default", "", false, null, false);
+    private AgentTemplate getAgentTemplate() {  
+        return new AgentTemplate("vmCredentialsId", "orka3xOption", null, "baseImage", 12, null, Constants.DEFAULT_NAMESPACE, true, false, false, "default", null, null, null, null, null, false, 1, Mode.NORMAL, "remoteFS", "label", new IdleTimeCloudRetentionStrategy(5), null, null);
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/helpers/VMNameGeneratorTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/helpers/VMNameGeneratorTest.java
@@ -1,0 +1,52 @@
+package io.jenkins.plugins.orka.helpers;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.util.regex.Pattern;
+
+public class VMNameGeneratorTest {
+    private static final Pattern VALID_CHARSET = Pattern.compile("^[a-z0-9]+$");
+    private static final int EXPECTED_SUFFIX_LENGTH = 5;
+    
+    @Test
+    public void testBasicFunctionality() {
+        String prefix = "test";
+        String result = VMNameGenerator.generateName(prefix);
+        
+        assertTrue(result.startsWith("test-"));
+        
+        assertEquals(prefix.length() + 1 + EXPECTED_SUFFIX_LENGTH, result.length());
+        
+        String suffix = result.substring(prefix.length() + 1);
+        assertTrue(VALID_CHARSET.matcher(suffix).matches());
+    }
+
+    @Test
+    public void testNoPrefix() {
+        String result = VMNameGenerator.generateName(null);
+        String expectedPrefix = "vm";
+        
+        assertTrue(result.startsWith(expectedPrefix + "-"));
+        
+        assertEquals(expectedPrefix.length() + 1 + EXPECTED_SUFFIX_LENGTH, result.length());
+        
+        String suffix = result.substring(expectedPrefix.length() + 1);
+        assertTrue(VALID_CHARSET.matcher(suffix).matches());
+    }
+    
+    @Test
+    public void testWithDifferentPrefixes() {
+        String[] prefixes = {"nginx", "my-pod", "web-server", "app123", "a"};
+        
+        for (String prefix : prefixes) {
+            String result = VMNameGenerator.generateName(prefix);
+            
+            assertTrue(result.startsWith(prefix + "-"));
+            assertEquals(prefix.length() + 1 + EXPECTED_SUFFIX_LENGTH, result.length());
+            
+            String suffix = result.substring(prefix.length() + 1);
+            assertTrue(VALID_CHARSET.matcher(suffix).matches());
+        }
+    }
+    
+}


### PR DESCRIPTION
## Description
The plugin now creates the VM names instead of relying on the K8s API to generate those.
This way the plugin knows about the VM if the deployment fails.
And it is able to delete the VM so no orphaned VMs are left.

## Testing

### Prerequisites

Build the plugin locally (Ensure your Java home points to Java 8): `mvn clean && mvn package`
Create an image with latest Java installed (you can use lab5 with this image `sonoma-java-24`)
Run Jenkins with `docker run --name jenkins-lts -p 8080:8080 -p 50000:50000 jenkins/jenkins:lts` (note the initial password is in the container logs)

### Upgrade Scenario

1. Install the official version of the plugin
2. Configure a cloud. Ensure you select "Advanced -> No Delay Provisioning` to create more VMs.
3. Configure a build to use the generated template. Here is a sample one: 
```
pipeline {
    agent none

    stages {
        stage('Run Jobs in Parallel') {
            parallel {
                stage('Job 1') {
                    agent { label 'orka' }
                    steps {
                        echo "Running Job 1 on an orka agent"
                        // Place your job logic here
                    }
                }
                stage('Job 2') {
                    agent { label 'orka' }
                    steps {
                        echo "Running Job 2 on an orka agent"
                    }
                }
                stage('Job 3') {
                    agent { label 'orka' }
                    steps {
                        echo "Running Job 3 on an orka agent"
                    }
                }
                stage('Job 4') {
                    agent { label 'orka' }
                    steps {
                        echo "Running Job 4 on an orka agent"
                    }
                }
                stage('Job 5') {
                    agent { label 'orka' }
                    steps {
                        echo "Running Job 5 on an orka agent"
                    }
                }
            }
        }
    }
}
```
4. Run the build to ensure it works
5. Upgrade the plugin: `Jenkins -> Manage Jenkins -> Plugins -> Advanced Settings` And choose the `hpi` file created by the build process (located in the target folder in the plugin directory)
6. Click deploy
7. Run the job again. This should work
8. Remove the operator and reduce the deployment timeout (Cloud -> Advanced Settings) to 10 sec
9. Run the job again. This should generate a ton of VMs with no status. Wait at least a minute
10. Stop the jobs
11. Redeploy the operator and wait some time. All VMs should be removed 
12. All VMs should be created with the `vm-` prefix. Change the prefxi from the Cloud config and rerun the job. Ensure the VMs are created with the new prefix

### Fresh scenario

Ensure you are running a fresh Jenkins.
Install the hpi file following the steps from above.
Repeat steps 2 to 11