### PR TITLE
[Cloud] Allow passing display settings to VMs

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -62,6 +62,9 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     private String config;
     private String tag;
     private Boolean tagRequired;
+    private Integer displayWidth;
+    private Integer displayHeight;
+    private Integer displayDpi;
 
     private String legacyConfigScheduler;
     private String legacyConfigTag;
@@ -109,12 +112,28 @@ public class AgentTemplate implements Describable<AgentTemplate> {
                 nodeProperties, jvmOptions);
     }
 
-    @DataBoundConstructor
+    @Deprecated
     public AgentTemplate(String vmCredentialsId, String deploymentOption, String namePrefix, String image, 
             int cpu, String memory, String namespace, boolean useNetBoost, boolean useLegacyIO, 
             boolean useGpuPassthrough, String scheduler, String tag, Boolean tagRequired, 
             String config, String legacyConfigScheduler, String legacyConfigTag, 
             boolean legacyConfigTagRequired, int numExecutors, Mode mode, String remoteFS,
+            String labelString, RetentionStrategy<?> retentionStrategy, 
+            List<? extends NodeProperty<?>> nodeProperties, String jvmOptions) {
+
+        this(vmCredentialsId, deploymentOption, namePrefix, image, cpu, memory, namespace, useNetBoost, useLegacyIO, 
+            useGpuPassthrough, scheduler, tag, tagRequired, config, legacyConfigScheduler, legacyConfigTag, 
+            legacyConfigTagRequired, null, null, null, numExecutors, mode, remoteFS, labelString, retentionStrategy, 
+            nodeProperties, jvmOptions);
+    }
+
+    @DataBoundConstructor
+    public AgentTemplate(String vmCredentialsId, String deploymentOption, String namePrefix, String image, 
+            int cpu, String memory, String namespace, boolean useNetBoost, boolean useLegacyIO, 
+            boolean useGpuPassthrough, String scheduler, String tag, Boolean tagRequired, 
+            String config, String legacyConfigScheduler, String legacyConfigTag, 
+            boolean legacyConfigTagRequired, Integer displayWidth, Integer displayHeight, Integer displayDpi, 
+            int numExecutors, Mode mode, String remoteFS,
             String labelString, RetentionStrategy<?> retentionStrategy, 
             List<? extends NodeProperty<?>> nodeProperties, String jvmOptions) {
 
@@ -144,6 +163,9 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         this.scheduler = scheduler;
         this.tag = tag;
         this.tagRequired = tagRequired;
+        this.displayWidth = displayWidth;
+        this.displayHeight = displayHeight;
+        this.displayDpi = displayDpi;
     }
 
     public String getOrkaCredentialsId() {
@@ -188,6 +210,18 @@ public class AgentTemplate implements Describable<AgentTemplate> {
 
     public String getScheduler() {
         return this.scheduler;
+    }
+
+    public Integer getDisplayWidth() {
+        return this.displayWidth;
+    }
+
+    public Integer getDisplayHeight() {
+        return this.displayHeight;
+    }
+
+    public Integer getDisplayDpi() {
+        return this.displayDpi;
     }
 
     public String getTag() {
@@ -300,9 +334,9 @@ public class AgentTemplate implements Describable<AgentTemplate> {
                     this.legacyConfigTagRequired, this.useNetBoost, this.useLegacyIO, this.useGpuPassthrough);
         }
         logger.fine("Using Orka 3x deployment for name " + name);
-        return this.parent.deployVMWithName(this.namespace, name, null, this.image,
+        return this.parent.deployVM(this.namespace, name, null, this.image,
                 this.cpu, this.memory, this.scheduler, this.tag, this.tagRequired,this.useNetBoost, 
-                this.useLegacyIO, this.useGpuPassthrough);
+                this.useLegacyIO, this.useGpuPassthrough, this.displayWidth, this.displayHeight, this.displayDpi);
     }
 
     void setParent(OrkaCloud parent) {
@@ -352,6 +386,22 @@ public class AgentTemplate implements Describable<AgentTemplate> {
             return this.formValidator.doCheckMemory(value);
         }
 
+        @POST
+        public FormValidation doCheckDisplayWidth(@QueryParameter String value) {
+            return this.formValidator.doCheckDisplayWidth(value);
+        }
+
+        @POST
+        public FormValidation doCheckDisplayHeight(@QueryParameter String value) {
+            return this.formValidator.doCheckDisplayHeight(value);
+        }
+
+        @POST
+        public FormValidation doCheckDisplayDpi(@QueryParameter String value) {
+            return this.formValidator.doCheckDisplayDpi(value);
+        }   
+
+        @POST
         public FormValidation doCheckNumExecutors(@QueryParameter String value) {
             return FormValidation.validatePositiveInteger(value);
         }
@@ -438,10 +488,11 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         return "AgentTemplate [namePrefix=" + namePrefix + ", image=" + image + ", cpu=" + cpu + ", memory=" + memory
                 + ", namespace=" + namespace + ", useNetBoost=" + useNetBoost + ", useGpuPassthrough="
                 + useGpuPassthrough + ", scheduler=" + scheduler + ", config=" + config + ", tag=" + tag
-                + ", tagRequired=" + tagRequired + ", legacyConfigScheduler=" + legacyConfigScheduler
+                + ", tagRequired=" + tagRequired + ", displayWidth=" + displayWidth + ", displayHeight=" + displayHeight
+                + ", displayDpi=" + displayDpi + ", legacyConfigScheduler=" + legacyConfigScheduler
                 + ", legacyConfigTag=" + legacyConfigTag + ", legacyConfigTagRequired=" + legacyConfigTagRequired
-                + ", deploymentOption=" + deploymentOption + ", numExecutors="
-                + numExecutors + ", mode=" + mode + ", remoteFS=" + remoteFS + ", labelString=" + labelString
-                + ", retentionStrategy=" + retentionStrategy + "]";
+                + ", deploymentOption=" + deploymentOption + ", numExecutors=" + numExecutors + ", mode=" + mode
+                + ", remoteFS=" + remoteFS + ", labelString=" + labelString + ", retentionStrategy=" + retentionStrategy
+                + "]";
     }
 }

--- a/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaCloud.java
@@ -190,6 +190,20 @@ public class OrkaCloud extends Cloud {
                           scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, null);
     }
 
+    public DeploymentResponse deployVM(String namespace, String name, String vmConfig, String image, 
+            Integer cpu, String memory, String scheduler, String tag,
+            Boolean tagRequired, Boolean netBoost, Boolean legacyIO, 
+            Boolean gpuPassThrough, Integer displayWidth, 
+            Integer displayHeight, Integer displayDpi) throws IOException {
+        return new OrkaClientFactory()
+                .getOrkaClient(this.endpoint, this.credentialsId, this.timeout, this.useJenkinsProxySettings,
+                        this.ignoreSSLErrors)
+                .deployVM(vmConfig, namespace, name, image, cpu, memory, null, 
+                        scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, null, 
+                        displayWidth, displayHeight, displayDpi);
+    }
+
+    @Deprecated
     public DeploymentResponse deployVMWithName(String namespace, String name, String vmConfig, String image, 
             Integer cpu, String memory, String scheduler, String tag,
             Boolean tagRequired, Boolean netBoost, Boolean legacyIO, 

--- a/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/DeploymentRequest.java
@@ -50,6 +50,15 @@ public class DeploymentRequest {
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     private String reservedPorts;
 
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    private Integer displayWidth;
+
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    private Integer displayHeight;
+
+    @SuppressFBWarnings("URF_UNREAD_FIELD")
+    private Integer displayDpi;
+
     @Deprecated
     public DeploymentRequest(String vmConfig, String name, String node, String scheduler,
             String tag, Boolean tagRequired) {
@@ -97,9 +106,18 @@ public class DeploymentRequest {
             legacyIO, gpuPassthrough, portMappingsString, StringUtils.isNotBlank(name));
     }
 
+    @Deprecated
     public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
         String scheduler, String tag, Boolean tagRequired, Boolean netBoost, Boolean legacyIO, Boolean gpuPassthrough, 
         String portMappingsString, Boolean shouldGenerateName) {
+        this(vmConfig, name, image, cpu, memory, node, scheduler, tag, tagRequired, netBoost, 
+            legacyIO, gpuPassthrough, portMappingsString, shouldGenerateName, null, null, null);
+    }
+
+    public DeploymentRequest(String vmConfig, String name, String image, Integer cpu, String memory, String node,
+        String scheduler, String tag, Boolean tagRequired, Boolean netBoost, Boolean legacyIO, Boolean gpuPassthrough, 
+        String portMappingsString, Boolean shouldGenerateName, 
+        Integer displayWidth, Integer displayHeight, Integer displayDpi) {
         this.vmConfig = vmConfig;
         this.node = node;
         this.image = image;
@@ -114,6 +132,9 @@ public class DeploymentRequest {
         this.netBoost = netBoost;
         this.legacyIO = legacyIO;
         this.gpuPassthrough = gpuPassthrough;
+        this.displayWidth = displayWidth;
+        this.displayHeight = displayHeight;
+        this.displayDpi = displayDpi;
 
         if (this.legacyIO) {
             this.netBoost = false;

--- a/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
+++ b/src/main/java/io/jenkins/plugins/orka/client/OrkaClient.java
@@ -106,6 +106,26 @@ public class OrkaClient {
         return response;
     }
 
+    public DeploymentResponse deployVM(String vmConfig, String namespace, String name, 
+            String image, Integer cpu, String memory, String node, String scheduler, String tag, 
+            Boolean tagRequired, Boolean netBoost, Boolean legacyIO, Boolean gpuPassThrough, 
+            String portMappingsString, Integer displayWidth, 
+            Integer displayHeight, Integer displayDpi) throws IOException {
+
+        DeploymentRequest deploymentRequest = new DeploymentRequest(vmConfig, name, image, cpu, memory, node,
+                scheduler, tag, tagRequired, netBoost, legacyIO, gpuPassThrough, portMappingsString, false, 
+                displayWidth, displayHeight, displayDpi);
+        String deploymentRequestJson = new Gson().toJson(deploymentRequest);
+
+        HttpResponse httpResponse = this.post(
+                String.format("%s/%s/%s/%s", this.endpoint, RESOURCE_PATH, namespace, VM_PATH), deploymentRequestJson);
+        DeploymentResponse response = JsonHelper.fromJson(httpResponse.getBody(), DeploymentResponse.class);
+        response.setHttpResponse(httpResponse);
+
+        return response;
+    }
+
+    @Deprecated
     public DeploymentResponse deployVMWithName(String vmConfig, String namespace, String name, 
             String image, Integer cpu, String memory, String node, String scheduler, String tag, 
             Boolean tagRequired, Boolean netBoost, Boolean legacyIO, Boolean gpuPassThrough, 

--- a/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
@@ -15,6 +15,12 @@ import org.apache.commons.lang.StringUtils;
 
 public class FormValidator {
     private static final Logger logger = Logger.getLogger(FormValidator.class.getName());
+    private static final int minDisplayWidth = 320;
+    private static final int maxDisplayWidth = 3840;
+    private static final int minDisplayHeight = 480;
+    private static final int maxDisplayHeight = 2160;
+    private static final int minDisplayDpi = 60;
+    private static final int maxDisplayDpi = 320;
 
     private OrkaClientFactory clientFactory;
 
@@ -72,8 +78,9 @@ public class FormValidator {
             }
             Integer width = Integer.parseInt(displayWidth);
 
-            if (width != 0 && (width < 320 || width > 3840)) {
-                return FormValidation.error("Display width shoud be 0 or between 320 and 3840");
+            if (width != 0 && (width < minDisplayWidth || width > maxDisplayWidth)) {
+                return FormValidation.error(String.format(
+                    "Display width shoud be 0 or between %d and %d", minDisplayWidth, maxDisplayWidth));
             }
             return FormValidation.ok();
         } catch (Exception e) {
@@ -92,8 +99,9 @@ public class FormValidator {
             }
             Integer height = Integer.parseInt(displayHeight);
 
-            if (height != 0 && (height < 480 || height > 2160)) {
-                return FormValidation.error("Display height shoud be 0 or between 480 and 2160");
+            if (height != 0 && (height < minDisplayHeight || height > maxDisplayHeight)) {
+                return FormValidation.error(String.format(
+                    "Display height shoud be 0 or between %d and %d", minDisplayHeight, maxDisplayHeight));
             }
             return FormValidation.ok();
         } catch (Exception e) {
@@ -112,8 +120,9 @@ public class FormValidator {
             }
             Integer dpi = Integer.parseInt(displayDpi);
 
-            if (dpi != 0 && (dpi < 60 || dpi > 320)) {
-                return FormValidation.error("Display dpi shoud be 0 or between 60 and 320");
+            if (dpi != 0 && (dpi < minDisplayDpi || dpi > maxDisplayDpi)) {
+                return FormValidation.error(String.format(
+                    "Display dpi shoud be 0 or between %d and %d", minDisplayDpi, maxDisplayDpi));
             }
             return FormValidation.ok();
         } catch (Exception e) {

--- a/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
+++ b/src/main/java/io/jenkins/plugins/orka/helpers/FormValidator.java
@@ -63,6 +63,66 @@ public class FormValidator {
         return FormValidation.error("Memory should be greater than 0");
     }
 
+    public FormValidation doCheckDisplayWidth(String displayWidth) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+        try {
+            if (StringUtils.isBlank(displayWidth)) {
+                return FormValidation.ok();
+            }
+            Integer width = Integer.parseInt(displayWidth);
+
+            if (width != 0 && (width < 320 || width > 3840)) {
+                return FormValidation.error("Display width shoud be 0 or between 320 and 3840");
+            }
+            return FormValidation.ok();
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Exception in doCheckDisplayWidth", e);
+        }
+
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckDisplayHeight(String displayHeight) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+        try {
+            if (StringUtils.isBlank(displayHeight)) {
+                return FormValidation.ok();
+            }
+            Integer height = Integer.parseInt(displayHeight);
+
+            if (height != 0 && (height < 480 || height > 2160)) {
+                return FormValidation.error("Display height shoud be 0 or between 480 and 2160");
+            }
+            return FormValidation.ok();
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Exception in doCheckDisplayHeight", e);
+        }
+
+        return FormValidation.ok();
+    }
+
+    public FormValidation doCheckDisplayDpi(String displayDpi) {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+        try {
+            if (StringUtils.isBlank(displayDpi)) {
+                return FormValidation.ok();
+            }
+            Integer dpi = Integer.parseInt(displayDpi);
+
+            if (dpi != 0 && (dpi < 60 || dpi > 320)) {
+                return FormValidation.error("Display dpi shoud be 0 or between 60 and 320");
+            }
+            return FormValidation.ok();
+        } catch (Exception e) {
+            logger.log(Level.WARNING, "Exception in doCheckDisplayDpi", e);
+        }
+
+        return FormValidation.ok();
+    }
+
     public FormValidation doCheckNamespace(String endpoint, String credentialsId, boolean useJenkinsProxySettings,
             boolean ignoreSSLErrors, String namespace) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -27,23 +27,41 @@
           <f:checkbox/>
         </f:entry>
 
-        <f:entry title="${%Use Net Boost}" field="useNetBoost" description="When checked, improves the network performance of Intel-based VMs. Required for macOS Ventura Intel-based VMs. 
-          NOTE: Applicable only to macOS BigSur and later. ">
-          <f:checkbox default="true" />
-        </f:entry>
-
-        <f:entry title="${%Use Legacy IO}" field="useLegacyIO" description="When checked, uses legacy IO network stack. Only enable for VMs before macOS 10.14.5">
-          <f:checkbox default="false" />
-        </f:entry>
-
-        <f:entry title="${%Use GPU Passthrough}" field="useGpuPassthrough" description="When checked, enables the VM to use the GPU available on the node. 
-          NOTE: GPU Passthrough must be enabled for the cluster.">
-          <f:checkbox default="false" />
-        </f:entry>
-
         <f:entry title="${%Scheduler}" field="scheduler">
           <f:select />
         </f:entry>
+
+        <f:advanced>
+          <f:entry title="${%Use Net Boost}" field="useNetBoost" description="When checked, improves the network performance of Intel-based VMs. Required for macOS Ventura Intel-based VMs. 
+            NOTE: Applicable only to macOS BigSur and later. ">
+            <f:checkbox default="true" />
+          </f:entry>
+
+          <f:entry title="${%Use Legacy IO}" field="useLegacyIO" description="When checked, uses legacy IO network stack. Only enable for VMs before macOS 10.14.5">
+            <f:checkbox default="false" />
+          </f:entry>
+
+          <f:entry title="${%Use GPU Passthrough}" field="useGpuPassthrough" description="When checked, enables the VM to use the GPU available on the node. 
+            NOTE: GPU Passthrough must be enabled for the cluster.">
+            <f:checkbox default="false" />
+          </f:entry>
+
+          <f:section title="${%Display Settings}">
+            <f:entry title="${%Width}" field="displayWidth">
+              <f:number />
+            </f:entry>
+
+            <f:entry title="${%Height}" field="displayHeight">
+              <f:number />
+            </f:entry>
+
+            <f:entry title="${%DPI}" field="displayDpi">
+              <f:number />
+            </f:entry>
+          </f:section>
+        </f:advanced>
+
+
       </orka:agentWrapper>
       <j:if test="${instance.config != null and instance.config != ''}">
         <f:radioBlock name="deploymentOption" value="${descriptor.getOrka2xOption()}" title="Orka 2.x Deployment" checked="${instance.deploymentOption == descriptor.getOrka2xOption()}" inline="true" help="${descriptor.getHelpFile('oldDeployment')}">

--- a/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/AgentTemplateTest.java
@@ -2,13 +2,11 @@ package io.jenkins.plugins.orka;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,8 +28,8 @@ public class AgentTemplateTest {
         String id = "vm-machine";
 
         OrkaCloud cloud = mock(OrkaCloud.class);
-        when(cloud.deployVMWithName(any(), any(), any(), any(), any(), any(), any(), any(),
-                any(), any(), any(), any()))
+        when(cloud.deployVM(any(), any(), any(), any(), any(), any(), any(), any(),
+                any(), any(), any(), any(), any(), any(), any()))
                 .thenReturn(new DeploymentResponse(ip, sshPort, id, null));
         when(cloud.getRealHost(anyString())).thenReturn(ip);
         agentTemplate.setParent(cloud);
@@ -49,6 +47,6 @@ public class AgentTemplateTest {
     }
 
     private AgentTemplate getAgentTemplate() {  
-        return new AgentTemplate("vmCredentialsId", "orka3xOption", null, "baseImage", 12, null, Constants.DEFAULT_NAMESPACE, true, false, false, "default", null, null, null, null, null, false, 1, Mode.NORMAL, "remoteFS", "label", new IdleTimeCloudRetentionStrategy(5), null, null);
+        return new AgentTemplate("vmCredentialsId", "orka3xOption", null, "baseImage", 12, null, Constants.DEFAULT_NAMESPACE, true, false, false, "default", null, null, null, null, null, false, 1500, 2000, 100, 1, Mode.NORMAL, "remoteFS", "label", new IdleTimeCloudRetentionStrategy(5), null, null);
     }
 }

--- a/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/GetTemplateTest.java
@@ -64,7 +64,7 @@ public class GetTemplateTest {
 
     private AgentTemplate getAgentTemplate(Mode mode, String label) {
         return new AgentTemplate("vmCredentialsId", "name", false, "configName", "baseImage", 12, true,
-                false, false, 1,
+                false, false,  1,
                 "remoteFS",
                 this.mode, this.label, "prefix", new IdleTimeCloudRetentionStrategy(5),
                 null,

--- a/src/test/java/io/jenkins/plugins/orka/client/OrkaClientTest.java
+++ b/src/test/java/io/jenkins/plugins/orka/client/OrkaClientTest.java
@@ -78,12 +78,12 @@ public class OrkaClientTest {
         OrkaClient client = mock(OrkaClient.class);
         when(client.post(anyString(), any())).thenReturn(response);
         when(client.deployVM(any(), anyString(), any(), any(), any(), any(), any(), any(),
-                any(), any(), any(), any(), any(), any()))
+                any(), any(), any(), any(), any(), any(), any(), any(), any()))
                 .thenCallRealMethod();
 
         DeploymentResponse actualResponse = client.deployVM("newVm", "orka-default", null, "foo.img", 6, "12", null,
                 null,
-                null, false,false, false, false, null);
+                null, false,false, false, false, null, 1500, 2000, 100);
 
         assertEquals(ip, actualResponse.getIP());
         assertEquals(sshPort, actualResponse.getSSH());


### PR DESCRIPTION
## Description

* [Cloud] Allow passing display settings to Orka

- Provide users with the ability to pass display settings to Orka
- Move rarely used VM settings to a separate "Advanced" section
- Add the display settings to this section

## Testing

Follow the [dev guide](https://github.com/jenkinsci/macstadium-orka-plugin/tree/main/development) to install the plugin locally

### Case 1

1. Create a new Cloud
2. Create a new Agent template
3. Do not set display settings
4. Create a new job that spins up agents from the cloud above
5. Run the job and ensure VMs are created
6. Check the VM display settings (from the pod labels). They should be the default ones

### Case 2

1. Create a new Cloud
2. Create a new Agent template
3. Set display settings
4. Create a new job that spins up agents from the cloud above
5. Run the job and ensure VMs are created
6. Check the VM display settings (from the pod labels). They should be the ones specified in (3)
