### PR TITLE
Add display settings to permanent agents

### DIFF
--- a/development/DEVELOPING.md
+++ b/development/DEVELOPING.md
@@ -53,7 +53,29 @@ To run the plugin locally with a Jenkins controller running the minimum supporte
 mvn hpi:run
 ```
 
+or with Docker:
+
+```
+docker run --name jenkins-lts -p 8080:8080 -p 50000:50000 jenkins/jenkins:lts
+```
+
+**Note**: If you are using Docker, you need the initial password. You can extract it from the container logs. Set up Jenkins following the default settings.
+
 Access the Jenkins controller at http://localhost:8080.
+
+## Installing the plugin
+
+Skip this section if you are not using Docker to run Jenkins.
+To install the plugin on a Jenkins in a Docker container:
+
+1. Build the plugin:
+```
+mvn package
+```
+1. Go to `Manage Jenkins` -> `Plugins` -> `Advanced Settings`
+1. Choose (or drag&drop) the `hpi` file from the `target` folder (created during the build step)
+1. Click `Deploy`
+1. **Note** If you upgrade the plugin you need to restart Jenkins. To do this navigate to `http://localhost:8080/restart`. This stops the container, so run it after that `docker start jenkins-lts`
 
 ## Entry Points
 

--- a/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaAgent.java
@@ -46,6 +46,9 @@ public class OrkaAgent extends AbstractCloudSlave {
     private boolean useNetBoost;
     private boolean useLegacyIO;
     private boolean useGpuPassthrough;
+    private Integer displayWidth;
+    private Integer displayHeight;
+    private Integer displayDpi;
     private String memory;
     private String tag;
     private Boolean tagRequired;
@@ -54,10 +57,38 @@ public class OrkaAgent extends AbstractCloudSlave {
 
     private final List<PortMapping> portMappings;
 
+    @Deprecated
+    public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId,
+        String node, String namespace, String namePrefix, String redirectHost, String image,
+        Integer cpu, boolean useNetBoost, boolean useLegacyIO, boolean useGpuPassthrough, 
+        int numExecutors, String host, int port, String remoteFS, boolean useJenkinsProxySettings, 
+        boolean ignoreSSLErrors, String jvmOptions, String memory, String tag, Boolean tagRequired)
+        throws Descriptor.FormException, IOException {
+        this(name, orkaCredentialsId, orkaEndpoint, vmCredentialsId, node, namespace, namePrefix, 
+            redirectHost, image, cpu, useNetBoost, useLegacyIO, useGpuPassthrough, numExecutors, 
+            host, port, remoteFS, useJenkinsProxySettings, ignoreSSLErrors, jvmOptions, memory, 
+            tag, tagRequired, null);
+    }
+
+    @Deprecated
+    public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId,
+            String node, String namespace, String namePrefix, String redirectHost, String image,
+            Integer cpu, boolean useNetBoost, boolean useLegacyIO, boolean useGpuPassthrough, 
+            int numExecutors, String host, int port, String remoteFS, boolean useJenkinsProxySettings, 
+            boolean ignoreSSLErrors, String jvmOptions, String memory, String tag, Boolean tagRequired, 
+            List<PortMapping> portMappings)
+            throws Descriptor.FormException, IOException {
+        this(name, orkaCredentialsId, orkaEndpoint, vmCredentialsId, node, namespace, namePrefix, 
+            redirectHost, image, cpu, useNetBoost, useLegacyIO, useGpuPassthrough, null, null, null, numExecutors, 
+            host, port, remoteFS, useJenkinsProxySettings, ignoreSSLErrors, jvmOptions, memory, 
+            tag, tagRequired, portMappings);
+    }
+
     @DataBoundConstructor
     public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId,
             String node, String namespace, String namePrefix, String redirectHost, String image,
             Integer cpu, boolean useNetBoost, boolean useLegacyIO, boolean useGpuPassthrough, 
+            Integer displayWidth, Integer displayHeight, Integer displayDpi,
             int numExecutors, String host, int port, String remoteFS, boolean useJenkinsProxySettings, 
             boolean ignoreSSLErrors, String jvmOptions, String memory, String tag, Boolean tagRequired, 
             List<PortMapping> portMappings)
@@ -76,6 +107,9 @@ public class OrkaAgent extends AbstractCloudSlave {
         this.useLegacyIO = useLegacyIO;
         this.useGpuPassthrough = useGpuPassthrough;
         this.useJenkinsProxySettings = useJenkinsProxySettings;
+        this.displayWidth = displayWidth;
+        this.displayHeight = displayHeight;
+        this.displayDpi = displayDpi;
         this.ignoreSSLErrors = ignoreSSLErrors;
         this.jvmOptions = jvmOptions;
         this.memory = memory;
@@ -83,35 +117,6 @@ public class OrkaAgent extends AbstractCloudSlave {
         this.tagRequired = tagRequired;
         this.setNumExecutors(numExecutors);
         this.portMappings = portMappings != null ? portMappings : new ArrayList<>();        
-    }
-
-    public OrkaAgent(String name, String orkaCredentialsId, String orkaEndpoint, String vmCredentialsId,
-            String node, String namespace, String namePrefix, String redirectHost, String image,
-            Integer cpu, boolean useNetBoost, boolean useLegacyIO, boolean useGpuPassthrough, 
-            int numExecutors, String host, int port, String remoteFS, boolean useJenkinsProxySettings, 
-            boolean ignoreSSLErrors, String jvmOptions, String memory, String tag, Boolean tagRequired)
-            throws Descriptor.FormException, IOException {
-        super(name, remoteFS, new OrkaComputerLauncher(host, port, redirectHost, jvmOptions));
-
-        this.orkaCredentialsId = orkaCredentialsId;
-        this.orkaEndpoint = orkaEndpoint;
-        this.vmCredentialsId = vmCredentialsId;
-        this.namespace = namespace;
-        this.namePrefix = namePrefix;
-        this.node = node;
-        this.image = image;
-        this.cpu = cpu;
-        this.useNetBoost = useNetBoost;
-        this.useLegacyIO = useLegacyIO;
-        this.useGpuPassthrough = useGpuPassthrough;
-        this.useJenkinsProxySettings = useJenkinsProxySettings;
-        this.ignoreSSLErrors = ignoreSSLErrors;
-        this.jvmOptions = jvmOptions;
-        this.memory = memory;
-        this.tag = tag;
-        this.tagRequired = tagRequired;
-        this.setNumExecutors(numExecutors);
-        this.portMappings = null;
     }
 
     public String getOrkaCredentialsId() {
@@ -164,6 +169,18 @@ public class OrkaAgent extends AbstractCloudSlave {
 
     public boolean getUseGpuPassthrough() {
         return this.useGpuPassthrough;
+    }
+
+    public Integer getDisplayWidth() {
+        return this.displayWidth;
+    }
+
+    public Integer getDisplayHeight() {
+        return this.displayHeight;
+    }
+
+    public Integer getDisplayDpi() {
+        return this.displayDpi;
     }
 
     public String getMemory() {
@@ -271,6 +288,21 @@ public class OrkaAgent extends AbstractCloudSlave {
         public ListBoxModel doFillVmCredentialsIdItems() {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             return CredentialsHelper.getCredentials(StandardCredentials.class);
+        }
+
+        @POST
+        public FormValidation doCheckDisplayWidth(@QueryParameter String displayWidth) {
+            return this.formValidator.doCheckDisplayWidth(displayWidth);
+        }
+
+        @POST
+        public FormValidation doCheckDisplayHeight(@QueryParameter String displayHeight) {  
+            return this.formValidator.doCheckDisplayHeight(displayHeight);
+        }
+
+        @POST
+        public FormValidation doCheckDisplayDpi(@QueryParameter String displayDpi) {
+            return this.formValidator.doCheckDisplayDpi(displayDpi);
         }
 
         @POST

--- a/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
+++ b/src/main/java/io/jenkins/plugins/orka/OrkaComputerLauncher.java
@@ -116,7 +116,8 @@ public final class OrkaComputerLauncher extends ComputerLauncher {
                 agent.getNode(),
                 null, agent.getTag(), agent.getTagRequired(),
                 agent.getUseNetBoost(), agent.getUseLegacyIO(), agent.getUseGpuPassthrough(), 
-                agent.getPortMappingsAsString());
+                agent.getPortMappingsAsString(), agent.getDisplayWidth(),
+                agent.getDisplayHeight(), agent.getDisplayDpi());
 
         if (!deploymentResponse.isSuccessful()) {
             logger.println(

--- a/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/OrkaAgent/configure-entries.jelly
@@ -59,19 +59,35 @@
       <f:checkbox/>
     </f:entry>
 
-    <f:entry title="${%Use Net Boost}" field="useNetBoost" description="When checked, improves the network performance of Intel-based VMs. Required for macOS Ventura Intel-based VMs. 
-      NOTE: Applicable only to macOS BigSur and later. ">
-      <f:checkbox default="true" />
-    </f:entry>
+    <f:advanced>
+      <f:entry title="${%Use Net Boost}" field="useNetBoost" description="When checked, improves the network performance of Intel-based VMs. Required for macOS Ventura Intel-based VMs. 
+        NOTE: Applicable only to macOS BigSur and later. ">
+        <f:checkbox default="true" />
+      </f:entry>
 
-    <f:entry title="${%Use Legacy IO}" field="useLegacyIO" description="When checked, uses legacy IO network stack. Only enable for VMs before macOS 10.14.5">
-      <f:checkbox default="false" />
-    </f:entry>
-    
-    <f:entry title="${%Use GPU Passthrough}" field="useGpuPassthrough" description="When checked, enables the VM to use the GPU available on the node. 
-        NOTE: GPU Passthrough must be enabled for the cluster.">
+      <f:entry title="${%Use Legacy IO}" field="useLegacyIO" description="When checked, uses legacy IO network stack. Only enable for VMs before macOS 10.14.5">
         <f:checkbox default="false" />
-    </f:entry>
+      </f:entry>
+      
+      <f:entry title="${%Use GPU Passthrough}" field="useGpuPassthrough" description="When checked, enables the VM to use the GPU available on the node. 
+          NOTE: GPU Passthrough must be enabled for the cluster.">
+          <f:checkbox default="false" />
+      </f:entry>
+
+      <f:section title="${%Display Settings}">
+        <f:entry title="${%Width}" field="displayWidth">
+          <f:number />
+        </f:entry>
+
+        <f:entry title="${%Height}" field="displayHeight">
+          <f:number />
+        </f:entry>
+
+        <f:entry title="${%DPI}" field="displayDpi">
+          <f:number />
+        </f:entry>
+      </f:section>
+    </f:advanced>
 
     <f:entry field="vmCredentialsId" title="${%VM Credentials}" description="Credentials used to connect to the VM">
       <c:select />


### PR DESCRIPTION
## Description

- Provide users with the ability to pass display settings to Orka
- Move rarely used VM settings to a separate "Advanced" section
- Add the display settings to this section

## Testing

Follow the [dev guide](https://github.com/jenkinsci/macstadium-orka-plugin/tree/main/development) to install the plugin locally

### Case 1

1. Create a new Node using the Orka template
2. Do not set display settings
3. Check the VM display settings (from the pod labels). They should be the default ones

### Case 2

1. Create a new Node using the Orka template
2. Set
3. Check the VM display settings (from the pod labels). They should be the ones provided
