### PR TITLE
Enable OCI compatibility 

### DIFF
--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -4,7 +4,7 @@
     <f:section title="${%ORKA VM Details}">
       <orka:agentWrapper name="deploymentOption" value="${descriptor.getOrka3xOption()}" title="Orka 3.x Deployment" checked="${instance.deploymentOption != descriptor.getOrka2xOption()}">
         <f:entry title="${%Image}" field="image">
-          <f:select checkMethod="post"/>
+          <f:textbox/>
         </f:entry>
 
         <f:invisibleEntry>


### PR DESCRIPTION
This PR allows the Orka plugin for Jenkins to use OCI image sources. 

### Testing

Build the plugin using Java 8 running `mvn clean build install`, install plugin to a jenkins instance, configure the orka cloud and set the image to an OCI registry string. 

