### PR TITLE
docs: add troubleshooting section and service account link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To create a permanent agent:
 
   Provide values for the following Orka properties:
 
-  - Orka Token - The service account token used to connect to the Orka environment. Created by running orka3 sa <name> token
+  - Orka Token - The [service account][service-account] token used to connect to the Orka environment. Created by running ```orka3 sa <name> token```
   - Orka Endpoint - The endpoint used by the plugin to connect to the Orka environment
   - Namespace - The namespace used to deploy VMs to
   - Node - The Orka node which the agent will be deployed on
@@ -65,7 +65,7 @@ To configure:
 - Select `Orka Cloud`
 - Configure the cloud by providing values for:
   - Name of this Cloud - The name of the cloud
-  - Orka Token - The service account token used to connect to the Orka environment. Created by running orka3 sa <name> token
+  - Orka Token - The [service account][service-account] token used to connect to the Orka environment. Created by running orka3 sa &lt;name&gt; token
   - Orka Endpoint - The endpoint used by the plugin to connect to the Orka environment
   - Click `Advanced` to also configure:
     - Max Jenkins Agents Limit - The maximum number of Orka VMs that can be created by that cloud instance. This allows you to better manage your Orka resources.
@@ -96,6 +96,27 @@ If you previously used an existing VM config to deploy VMs, you will see a radio
 - Orka 3.x Deployment - The new way of deploying VMs. Does not require a VM config. If you previously had `Create a new VM config` enabled, your settings have been automatically migrated to this option
 - Orka 2.x Deployment - The legacy way of deploying VMs. If you previously used an existing VM config, your settings have been automatically migrated to this option. All settings are `read-only`. If you need to make changes, you will need to migrate to the `Orka 3.x Deployment` option.
 
+#### Troubleshooting
+
+##### Enabling Plugin Logs
+
+The Orka plugin uses [Jenkins built-in logging framework]. To capture plugin logs for troubleshooting:
+
+1. Go to **Manage Jenkins -> System Log.**
+2. Click **Add new log recorder** and give it a name (e.g., ```Orka Plugin Logs```).
+3. Under **Loggers**, click **Add** and enter:
+
+   io.jenkins.plugins.orka
+
+Set the log level to **All** and click **Save**.
+
+- Logs will appear under **Manage Jenkins -> System Log ->** *(your recorder name).*
+- Reducing log volume: The ```All``` level can slow down Jenkins on busy instances. To collect the most useful logs with less overhead, scope the logger to the core cloud class:
+
+```io.jenkins.plugins.orka.OrkaCloud```
+
+Keep the log level set to **All**.
+
 ## Changelog
 
 After version `1.4` [here][changelog].
@@ -105,4 +126,5 @@ Prior to version `1.4` [here][old-changelog].
 [orka]: https://www.macstadium.com/orka
 [changelog]: https://github.com/jenkinsci/macstadium-orka-plugin/releases
 [old-changelog]: https://wiki.jenkins.io/display/JENKINS/Orka+Change+Log
-[service account]: https://support.macstadium.com/hc/en-us/articles/28333065069211-Orka-Cluster-Manage-Service-Accounts
+[Jenkins built-in logging framework]: https://www.jenkins.io/doc/book/system-administration/viewing-logs/
+[service-account]: https://support.macstadium.com/hc/en-us/articles/28333065069211-Orka-Cluster-Manage-Service-Accounts

--- a/README.md
+++ b/README.md
@@ -111,11 +111,7 @@ The Orka plugin uses [Jenkins built-in logging framework]. To capture plugin log
 Set the log level to **All** and click **Save**.
 
 - Logs will appear under **Manage Jenkins -> System Log ->** *(your recorder name).*
-- Reducing log volume: The ```All``` level can slow down Jenkins on busy instances. To collect the most useful logs with less overhead, scope the logger to the core cloud class:
-
-```io.jenkins.plugins.orka.OrkaCloud```
-
-Keep the log level set to **All**.
+- The `io.jenkins.plugins.orka` scope is recommended, as narrowing to a specific class may omit relevant logs. Note that the `All` level can increase overhead on busy instances.
 
 ## Changelog
 


### PR DESCRIPTION
Two documentation improvements to the README:

Troubleshooting section: This PR adds a new section under Ephemeral Agents covering how to enable and capture plugin logs using the Jenkins built-in logging framework, including guidance on scoping the logger to reduce noise on busy instances

Service account link updated: The Orka Token field description in both the Permanent and Ephemeral agent setup sections now links to the MacStadium service account documentation

JIRA: https://macstadium.atlassian.net/jira/software/projects/DI/boards/1129?selectedIssue=DI-473 and https://macstadium.atlassian.net/jira/polaris/projects/MPD/ideas/view/9904365?selectedIssue=MPD-46

### Submitter checklist
- [ x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
