### PR TITLE
Allow using VM configs for agent configurations

### DIFF
--- a/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
+++ b/src/main/java/io/jenkins/plugins/orka/AgentTemplate.java
@@ -48,6 +48,8 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     private static final Logger logger = Logger.getLogger(AgentTemplate.class.getName());
     private static final String orka3xOption = "orka3xOption";
     private static final String orka2xOption = "orka2xOption";
+    private static final String orka3xDirectOption = "orka3xDirect";
+    private static final String orka3xVmConfigOption = "orka3xVmConfig";
     private String vmCredentialsId;
 
     private String namePrefix;
@@ -71,6 +73,8 @@ public class AgentTemplate implements Describable<AgentTemplate> {
     private Boolean legacyConfigTagRequired;
 
     private String deploymentOption;
+    private String orka3xInputMode;
+    private String orka3xVmConfig;
 
     private int numExecutors;
     private Mode mode;
@@ -127,14 +131,32 @@ public class AgentTemplate implements Describable<AgentTemplate> {
             nodeProperties, jvmOptions);
     }
 
-    @DataBoundConstructor
-    public AgentTemplate(String vmCredentialsId, String deploymentOption, String namePrefix, String image, 
-            int cpu, String memory, String namespace, boolean useNetBoost, boolean useLegacyIO, 
-            boolean useGpuPassthrough, String scheduler, String tag, Boolean tagRequired, 
-            String config, String legacyConfigScheduler, String legacyConfigTag, 
-            boolean legacyConfigTagRequired, Integer displayWidth, Integer displayHeight, Integer displayDpi, 
+    @Deprecated
+    public AgentTemplate(String vmCredentialsId, String deploymentOption, String namePrefix, String image,
+            int cpu, String memory, String namespace, boolean useNetBoost, boolean useLegacyIO,
+            boolean useGpuPassthrough, String scheduler, String tag, Boolean tagRequired,
+            String config, String legacyConfigScheduler, String legacyConfigTag,
+            boolean legacyConfigTagRequired, Integer displayWidth, Integer displayHeight, Integer displayDpi,
             int numExecutors, Mode mode, String remoteFS,
-            String labelString, RetentionStrategy<?> retentionStrategy, 
+            String labelString, RetentionStrategy<?> retentionStrategy,
+            List<? extends NodeProperty<?>> nodeProperties, String jvmOptions) {
+
+        this(vmCredentialsId, deploymentOption, namePrefix, image, cpu, memory, namespace, useNetBoost,
+                useLegacyIO, useGpuPassthrough, scheduler, tag, tagRequired, config, legacyConfigScheduler,
+                legacyConfigTag, legacyConfigTagRequired, displayWidth, displayHeight, displayDpi,
+                null, null,
+                numExecutors, mode, remoteFS, labelString, retentionStrategy, nodeProperties, jvmOptions);
+    }
+
+    @DataBoundConstructor
+    public AgentTemplate(String vmCredentialsId, String deploymentOption, String namePrefix, String image,
+            int cpu, String memory, String namespace, boolean useNetBoost, boolean useLegacyIO,
+            boolean useGpuPassthrough, String scheduler, String tag, Boolean tagRequired,
+            String config, String legacyConfigScheduler, String legacyConfigTag,
+            boolean legacyConfigTagRequired, Integer displayWidth, Integer displayHeight, Integer displayDpi,
+            String orka3xInputMode, String orka3xVmConfig,
+            int numExecutors, Mode mode, String remoteFS,
+            String labelString, RetentionStrategy<?> retentionStrategy,
             List<? extends NodeProperty<?>> nodeProperties, String jvmOptions) {
 
         this.vmCredentialsId = vmCredentialsId;
@@ -166,6 +188,8 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         this.displayWidth = displayWidth;
         this.displayHeight = displayHeight;
         this.displayDpi = displayDpi;
+        this.orka3xInputMode = orka3xInputMode;
+        this.orka3xVmConfig = orka3xVmConfig;
     }
 
     public String getOrkaCredentialsId() {
@@ -264,6 +288,14 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         return this.deploymentOption;
     }
 
+    public String getOrka3xInputMode() {
+        return this.orka3xInputMode;
+    }
+
+    public String getOrka3xVmConfig() {
+        return this.orka3xVmConfig;
+    }
+
     public String getLegacyConfigScheduler() {
         return this.legacyConfigScheduler;
     }
@@ -333,9 +365,16 @@ public class AgentTemplate implements Describable<AgentTemplate> {
                     null, this.legacyConfigScheduler, this.legacyConfigTag, 
                     this.legacyConfigTagRequired, this.useNetBoost, this.useLegacyIO, this.useGpuPassthrough);
         }
+        if (StringUtils.equals(orka3xInputMode, orka3xVmConfigOption)) {
+            logger.fine("Using Orka 3x deployment with VM config " + this.orka3xVmConfig);
+            return this.parent.deployVM(this.namespace, name, this.orka3xVmConfig, null,
+                    null, null, this.scheduler, this.tag, this.tagRequired,
+                    this.useNetBoost, this.useLegacyIO, this.useGpuPassthrough,
+                    this.displayWidth, this.displayHeight, this.displayDpi);
+        }
         logger.fine("Using Orka 3x deployment for name " + name);
         return this.parent.deployVM(this.namespace, name, null, this.image,
-                this.cpu, this.memory, this.scheduler, this.tag, this.tagRequired,this.useNetBoost, 
+                this.cpu, this.memory, this.scheduler, this.tag, this.tagRequired, this.useNetBoost,
                 this.useLegacyIO, this.useGpuPassthrough, this.displayWidth, this.displayHeight, this.displayDpi);
     }
 
@@ -363,6 +402,9 @@ public class AgentTemplate implements Describable<AgentTemplate> {
             this.legacyConfigTag = tag;
             this.legacyConfigScheduler = scheduler;
             this.deploymentOption = orka2xOption;
+        }
+        if (StringUtils.isBlank(this.orka3xInputMode)) {
+            this.orka3xInputMode = orka3xDirectOption;
         }
 
         return this;
@@ -463,6 +505,24 @@ public class AgentTemplate implements Describable<AgentTemplate> {
         public String getOrka3xOption() {
             return AgentTemplate.orka3xOption;
         }
+
+        public String getOrka3xDirectOption() {
+            return AgentTemplate.orka3xDirectOption;
+        }
+
+        public String getOrka3xVmConfigOption() {
+            return AgentTemplate.orka3xVmConfigOption;
+        }
+
+        @POST
+        public ListBoxModel doFillOrka3xVmConfigItems(
+                @QueryParameter @RelativePath("..") String endpoint,
+                @QueryParameter @RelativePath("..") String credentialsId,
+                @QueryParameter @RelativePath("..") Boolean useJenkinsProxySettings,
+                @QueryParameter @RelativePath("..") Boolean ignoreSSLErrors) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+            return this.infoHelper.doFillVmItems(endpoint, credentialsId, useJenkinsProxySettings, ignoreSSLErrors);
+        }
     }
 
     @Override
@@ -473,7 +533,8 @@ public class AgentTemplate implements Describable<AgentTemplate> {
                 + ", tagRequired=" + tagRequired + ", displayWidth=" + displayWidth + ", displayHeight=" + displayHeight
                 + ", displayDpi=" + displayDpi + ", legacyConfigScheduler=" + legacyConfigScheduler
                 + ", legacyConfigTag=" + legacyConfigTag + ", legacyConfigTagRequired=" + legacyConfigTagRequired
-                + ", deploymentOption=" + deploymentOption + ", numExecutors=" + numExecutors + ", mode=" + mode
+                + ", deploymentOption=" + deploymentOption + ", orka3xInputMode=" + orka3xInputMode
+                + ", orka3xVmConfig=" + orka3xVmConfig + ", numExecutors=" + numExecutors + ", mode=" + mode
                 + ", remoteFS=" + remoteFS + ", labelString=" + labelString + ", retentionStrategy=" + retentionStrategy
                 + "]";
     }

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/config.jelly
@@ -3,65 +3,80 @@
   <orka:blockWrapper>
     <f:section title="${%ORKA VM Details}">
       <orka:agentWrapper name="deploymentOption" value="${descriptor.getOrka3xOption()}" title="Orka 3.x Deployment" checked="${instance.deploymentOption != descriptor.getOrka2xOption()}">
-        <f:entry title="${%Image}" field="image" help="${descriptor.getHelpFile('image')}">
-          <f:textbox checkMethod="post"/>
-        </f:entry>
-
-        <f:invisibleEntry>
-          <f:readOnlyTextbox name="readonlyImage" value="${instance.image}"/>
-        </f:invisibleEntry>
-
-        <f:entry title="${%# of CPUs}" field="cpu">
-          <f:number min="1" default="2"/>
-        </f:entry>
-
-        <f:entry title="${%Memory in G}" field="memory" help="${descriptor.getHelpFile('memory')}">
-          <f:textbox checkMethod="post" default="auto"/>
-        </f:entry>
-
-        <f:entry title="${%Tag}" field="tag" help="${descriptor.getHelpFile('tag')}">
-          <f:textbox/>
-        </f:entry>
-
-        <f:entry title="${%Tag Required}" field="tagRequired" help="${descriptor.getHelpFile('tagRequired')}">
-          <f:checkbox/>
-        </f:entry>
-
-        <f:entry title="${%Scheduler}" field="scheduler">
-          <f:select />
-        </f:entry>
-
-        <f:advanced>
-          <f:entry title="${%Use Net Boost}" field="useNetBoost" description="When checked, improves the network performance of Intel-based VMs. Required for macOS Ventura Intel-based VMs. 
-            NOTE: Applicable only to macOS BigSur and later. ">
-            <f:checkbox default="true" />
+        <f:radioBlock name="orka3xInputMode"
+                      value="${descriptor.getOrka3xDirectOption()}"
+                      title="${%Specify values directly}"
+                      checked="${instance.orka3xInputMode == null or instance.orka3xInputMode == '' or instance.orka3xInputMode == descriptor.getOrka3xDirectOption()}"
+                      inline="true"
+                      help="${descriptor.getHelpFile('orka3xInputMode')}">
+          <f:entry title="${%Image}" field="image" help="${descriptor.getHelpFile('image')}">
+            <f:textbox checkMethod="post"/>
           </f:entry>
 
-          <f:entry title="${%Use Legacy IO}" field="useLegacyIO" description="When checked, uses legacy IO network stack. Only enable for VMs before macOS 10.14.5">
-            <f:checkbox default="false" />
+          <f:invisibleEntry>
+            <f:readOnlyTextbox name="readonlyImage" value="${instance.image}"/>
+          </f:invisibleEntry>
+
+          <f:entry title="${%# of CPUs}" field="cpu">
+            <f:number min="1" default="2"/>
           </f:entry>
 
-          <f:entry title="${%Use GPU Passthrough}" field="useGpuPassthrough" description="When checked, enables the VM to use the GPU available on the node. 
-            NOTE: GPU Passthrough must be enabled for the cluster.">
-            <f:checkbox default="false" />
+          <f:entry title="${%Memory in G}" field="memory" help="${descriptor.getHelpFile('memory')}">
+            <f:textbox checkMethod="post" default="auto"/>
           </f:entry>
 
-          <f:section title="${%Display Settings}">
-            <f:entry title="${%Width}" field="displayWidth">
-              <f:number />
+          <f:entry title="${%Tag}" field="tag" help="${descriptor.getHelpFile('tag')}">
+            <f:textbox/>
+          </f:entry>
+
+          <f:entry title="${%Tag Required}" field="tagRequired" help="${descriptor.getHelpFile('tagRequired')}">
+            <f:checkbox/>
+          </f:entry>
+
+          <f:entry title="${%Scheduler}" field="scheduler">
+            <f:select />
+          </f:entry>
+
+          <f:advanced>
+            <f:entry title="${%Use Net Boost}" field="useNetBoost" description="When checked, improves the network performance of Intel-based VMs. Required for macOS Ventura Intel-based VMs.
+              NOTE: Applicable only to macOS BigSur and later. ">
+              <f:checkbox default="true" />
             </f:entry>
 
-            <f:entry title="${%Height}" field="displayHeight">
-              <f:number />
+            <f:entry title="${%Use Legacy IO}" field="useLegacyIO" description="When checked, uses legacy IO network stack. Only enable for VMs before macOS 10.14.5">
+              <f:checkbox default="false" />
             </f:entry>
 
-            <f:entry title="${%DPI}" field="displayDpi">
-              <f:number />
+            <f:entry title="${%Use GPU Passthrough}" field="useGpuPassthrough" description="When checked, enables the VM to use the GPU available on the node.
+              NOTE: GPU Passthrough must be enabled for the cluster.">
+              <f:checkbox default="false" />
             </f:entry>
-          </f:section>
-        </f:advanced>
 
+            <f:section title="${%Display Settings}">
+              <f:entry title="${%Width}" field="displayWidth">
+                <f:number />
+              </f:entry>
 
+              <f:entry title="${%Height}" field="displayHeight">
+                <f:number />
+              </f:entry>
+
+              <f:entry title="${%DPI}" field="displayDpi">
+                <f:number />
+              </f:entry>
+            </f:section>
+          </f:advanced>
+        </f:radioBlock>
+
+        <f:radioBlock name="orka3xInputMode"
+                      value="${descriptor.getOrka3xVmConfigOption()}"
+                      title="${%Use a VM Config}"
+                      checked="${instance.orka3xInputMode == descriptor.getOrka3xVmConfigOption()}"
+                      inline="true">
+          <f:entry title="${%VM Config}" field="orka3xVmConfig" help="${descriptor.getHelpFile('orka3xVmConfig')}">
+            <f:select />
+          </f:entry>
+        </f:radioBlock>
       </orka:agentWrapper>
       <j:if test="${instance.config != null and instance.config != ''}">
         <f:radioBlock name="deploymentOption" value="${descriptor.getOrka2xOption()}" title="Orka 2.x Deployment" checked="${instance.deploymentOption == descriptor.getOrka2xOption()}" inline="true" help="${descriptor.getHelpFile('oldDeployment')}">
@@ -91,7 +106,7 @@
       <f:entry title="${%Name Prefix}" field="namePrefix" help="${descriptor.getHelpFile('namePrefix')}">
         <f:textbox/>
       </f:entry>
-      
+
       <f:entry field="vmCredentialsId" title="${%VM Credentials}" description="Credentials used to connect to the VM">
         <c:select />
       </f:entry>

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/help-orka3xInputMode.html
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/help-orka3xInputMode.html
@@ -1,0 +1,7 @@
+<div>
+  Choose how to configure the VM for this agent template.
+  <ul>
+    <li><b>Specify values directly</b> — set image, CPU, memory, tag, and other options explicitly. Use this when you want to provide the VM parameters directly from Jenkins.</li>
+    <li><b>Use a VM Config</b> — select a pre-defined VM configuration created in Orka. Use this when you need options that are not available in the direct values UI, or you want to manage the VM configuration from within Orka (this allows you to change VM parameters without having to make any Jenkins changes).</li>
+  </ul>
+</div>

--- a/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/help-orka3xVmConfig.html
+++ b/src/main/resources/io/jenkins/plugins/orka/AgentTemplate/help-orka3xVmConfig.html
@@ -1,0 +1,5 @@
+<div>
+  The name of an existing VM configuration defined in Orka.
+  VM configurations bundle image, CPU, memory, and other settings into a reusable template.
+  All VM parameters will be sourced from the selected config.
+</div>


### PR DESCRIPTION
## Description

* Allow using VM configs for agent configurations

This allows users to set VM settings not available in the direct values UI.

## Testing

1. Install the plugin.
2. Create a new cloud
3. Create a new VM config
4. Select the option for VM configs in the VM template section
5. Create a job to use the template
6. Run the job

